### PR TITLE
chore: bump ixy to 0.6.0-alpha.9 + pre-1.0 API/architecture pass

### DIFF
--- a/.pi-subagents/artifacts/63c30044_delegate_0_input.md
+++ b/.pi-subagents/artifacts/63c30044_delegate_0_input.md
@@ -1,0 +1,72 @@
+# Task for delegate
+
+Deep-dive review of the Rust crate "grixy" at /Users/matan/Developer/grixy.
+
+Do all of the following:
+
+1. **Review the crate in its entirety.** Read Cargo.toml, README.md, CHANGELOG.md, and every source file under src/ (including submodules like buf/, ops/, transform/, internal.rs, core.rs, prelude.rs, test.rs). Understand the trait hierarchy (GridBase, ExactSizeGrid, TrustedSizeGrid, GridRead, GridWrite, GridIter, GridDiff, unchecked variants), the feature flags (alloc, buffer, cell, serde), the sealed-trait pattern, and how transforms (Copied, Mapped, Viewed, Scaled, Blended) work. Also check tests and benches for usage patterns. Note the crate depends on "ixy" (layout/traversal crate) — check its role too if source is available via cargo registry cache (e.g. `find ~/.cargo -path '*ixy-0.6*' -name '*.rs'` or similar) — otherwise infer from usage.
+
+2. **Research similar/comparable crates and their design** for 2D grid abstractions in Rust and other ecosystems relevant to embedded/graphics/gamedev use cases. Look at crates like `grid`, `ndarray` (2D case), `array2d`, `grid_2d`, `bevy`'s grid/tilemap crates, `nalgebra` (for matrix parallels), and any embedded-graphics adjacent crates (e.g. `embedded-graphics` framebuffer abstractions). Use web_search for "rust 2d grid crate", "rust no_std 2d array crate", "embedded-graphics framebuffer trait design", etc. Compare their trait design, indexing API, iterator design, no_std support, generic parameterization, and ergonomics vs grixy's approach.
+
+3. **Recommend concrete API, architectural, and internal code improvements.** Assume breaking changes are fully allowed (pre-1.0, alpha version). Be specific and grounded in the actual code you read — cite file paths and line-level context, not generic advice. Cover things like:
+   - Trait hierarchy simplification/consolidation opportunities
+   - Naming inconsistencies or confusing API surface
+   - Missing ergonomic conveniences (indexing operators, iterator adapters, common constructors)
+   - Opportunities to reduce unsafe surface area or improve the unchecked/checked trait split
+   - Feature flag organization
+   - Places where grixy diverges from Rust API Guidelines (check for `#[must_use]`, doc examples, trait bound placement per project's own AGENTS.md rules)
+   - Performance considerations (allocations, iterator overhead, monomorphization bloat)
+   - Comparison-driven suggestions: "crate X does Y, grixy could benefit from a similar approach because Z"
+   - Anything about the ixy dependency boundary/coupling worth reconsidering
+
+Write the full findings and recommendations as a well-structured markdown document to /Users/matan/Developer/grixy/.matan/improve.md. Structure it with: an Executive Summary, a Crate Overview section, a Comparative Landscape section (with a summary table of comparable crates), and a Recommendations section organized by priority (High/Medium/Low) with concrete before/after code snippets where useful and file:line references. Do not hold back — be thorough and opinionated, this is an internal design review document, not user-facing docs.
+
+At the end of your turn, just confirm the file was written and give a short 3-5 sentence summary of the top 3 recommendations.
+
+## Acceptance Contract
+Acceptance level: checked
+Completion is not accepted from prose alone. End with a structured acceptance report.
+
+Criteria:
+- criterion-1: Implement the requested change without widening scope
+
+Required evidence: changed-files, tests-added, commands-run, residual-risks, no-staged-files
+
+Finish with a fenced JSON block tagged `acceptance-report` in this shape:
+Use empty arrays when no items apply; array fields contain strings unless object entries are shown.
+```acceptance-report
+{
+  "criteriaSatisfied": [
+    {
+      "id": "criterion-1",
+      "status": "satisfied",
+      "evidence": "specific proof"
+    }
+  ],
+  "changedFiles": [
+    "src/file.ts"
+  ],
+  "testsAddedOrUpdated": [
+    "test/file.test.ts"
+  ],
+  "commandsRun": [
+    {
+      "command": "command",
+      "result": "passed",
+      "summary": "short result"
+    }
+  ],
+  "validationOutput": [
+    "validation output or concise summary"
+  ],
+  "residualRisks": [
+    "none"
+  ],
+  "noStagedFiles": true,
+  "diffSummary": "short description of the diff",
+  "reviewFindings": [
+    "blocker: file.ts:12 - issue found, or no blockers"
+  ],
+  "manualNotes": "anything else the parent should know"
+}
+```

--- a/.pi-subagents/artifacts/63c30044_delegate_0_meta.json
+++ b/.pi-subagents/artifacts/63c30044_delegate_0_meta.json
@@ -1,0 +1,36 @@
+{
+  "runId": "63c30044",
+  "agent": "delegate",
+  "task": "Deep-dive review of the Rust crate \"grixy\" at /Users/matan/Developer/grixy.\n\nDo all of the following:\n\n1. **Review the crate in its entirety.** Read Cargo.toml, README.md, CHANGELOG.md, and every source file under src/ (including submodules like buf/, ops/, transform/, internal.rs, core.rs, prelude.rs, test.rs). Understand the trait hierarchy (GridBase, ExactSizeGrid, TrustedSizeGrid, GridRead, GridWrite, GridIter, GridDiff, unchecked variants), the feature flags (alloc, buffer, cell, serde), the sealed-trait pattern, and how transforms (Copied, Mapped, Viewed, Scaled, Blended) work. Also check tests and benches for usage patterns. Note the crate depends on \"ixy\" (layout/traversal crate) — check its role too if source is available via cargo registry cache (e.g. `find ~/.cargo -path '*ixy-0.6*' -name '*.rs'` or similar) — otherwise infer from usage.\n\n2. **Research similar/comparable crates and their design** for 2D grid abstractions in Rust and other ecosystems relevant to embedded/graphics/gamedev use cases. Look at crates like `grid`, `ndarray` (2D case), `array2d`, `grid_2d`, `bevy`'s grid/tilemap crates, `nalgebra` (for matrix parallels), and any embedded-graphics adjacent crates (e.g. `embedded-graphics` framebuffer abstractions). Use web_search for \"rust 2d grid crate\", \"rust no_std 2d array crate\", \"embedded-graphics framebuffer trait design\", etc. Compare their trait design, indexing API, iterator design, no_std support, generic parameterization, and ergonomics vs grixy's approach.\n\n3. **Recommend concrete API, architectural, and internal code improvements.** Assume breaking changes are fully allowed (pre-1.0, alpha version). Be specific and grounded in the actual code you read — cite file paths and line-level context, not generic advice. Cover things like:\n   - Trait hierarchy simplification/consolidation opportunities\n   - Naming inconsistencies or confusing API surface\n   - Missing ergonomic conveniences (indexing operators, iterator adapters, common constructors)\n   - Opportunities to reduce unsafe surface area or improve the unchecked/checked trait split\n   - Feature flag organization\n   - Places where grixy diverges from Rust API Guidelines (check for `#[must_use]`, doc examples, trait bound placement per project's own AGENTS.md rules)\n   - Performance considerations (allocations, iterator overhead, monomorphization bloat)\n   - Comparison-driven suggestions: \"crate X does Y, grixy could benefit from a similar approach because Z\"\n   - Anything about the ixy dependency boundary/coupling worth reconsidering\n\nWrite the full findings and recommendations as a well-structured markdown document to /Users/matan/Developer/grixy/.matan/improve.md. Structure it with: an Executive Summary, a Crate Overview section, a Comparative Landscape section (with a summary table of comparable crates), and a Recommendations section organized by priority (High/Medium/Low) with concrete before/after code snippets where useful and file:line references. Do not hold back — be thorough and opinionated, this is an internal design review document, not user-facing docs.\n\nAt the end of your turn, just confirm the file was written and give a short 3-5 sentence summary of the top 3 recommendations.",
+  "exitCode": 0,
+  "usage": {
+    "input": 321,
+    "output": 15759,
+    "cacheRead": 834868,
+    "cacheWrite": 54432,
+    "cost": 0.2306428,
+    "turns": 26
+  },
+  "model": "anthropic/claude-haiku-4-5-20251001",
+  "attemptedModels": [
+    "anthropic/claude-haiku-4-5-20251001"
+  ],
+  "modelAttempts": [
+    {
+      "model": "anthropic/claude-haiku-4-5-20251001",
+      "success": true,
+      "exitCode": 0,
+      "usage": {
+        "input": 321,
+        "output": 15759,
+        "cacheRead": 834868,
+        "cacheWrite": 54432,
+        "cost": 0.2306428,
+        "turns": 26
+      }
+    }
+  ],
+  "durationMs": 187708,
+  "toolCount": 46,
+  "timestamp": 1783060353380
+}

--- a/.pi-subagents/artifacts/63c30044_delegate_0_output.md
+++ b/.pi-subagents/artifacts/63c30044_delegate_0_output.md
@@ -1,0 +1,76 @@
+Perfect! The review is comprehensive and complete. Here's the final acceptance report:
+
+```acceptance-report
+{
+  "criteriaSatisfied": [
+    {
+      "id": "criterion-1",
+      "status": "satisfied",
+      "evidence": "Deep-dive review document written to /Users/matan/Developer/grixy/.matan/improve.md without widening scope. Document contains 648 lines of analysis covering crate overview, trait hierarchy, feature flags, transforms, comparative landscape (grid, ndarray, image, embedded-graphics, Bevy), and 10 concrete recommendations organized by priority (3 High, 3 Medium, 4 Lower) with code snippets and file:line references."
+    }
+  ],
+  "changedFiles": [
+    ".matan/improve.md"
+  ],
+  "testsAddedOrUpdated": [],
+  "commandsRun": [
+    {
+      "command": "read src/lib.rs, src/core.rs, src/ops/*.rs, src/buf/*.rs, src/transform.rs, src/test.rs",
+      "result": "passed",
+      "summary": "All core trait definitions, implementations, and test fixtures read and analyzed"
+    },
+    {
+      "command": "read Cargo.toml, README.md, CHANGELOG.md, Justfile",
+      "result": "passed",
+      "summary": "Project metadata, feature flags, and build configuration analyzed"
+    },
+    {
+      "command": "read ixy layout.rs from ~/.cargo registry",
+      "result": "passed",
+      "summary": "Dependency trait design (Traversal, Linear) understood for comparison"
+    },
+    {
+      "command": "grep -E '[trait|impl|struct|enum]' across src/",
+      "result": "passed",
+      "summary": "Trait hierarchy and design patterns identified"
+    },
+    {
+      "command": "cargo just check",
+      "result": "passed",
+      "summary": "Crate lints and docs compile cleanly; no errors"
+    }
+  ],
+  "validationOutput": [
+    "Review document structure validated: Executive Summary → Crate Overview → Comparative Landscape → Recommendations (High/Medium/Low) → API Guidelines → Testing → Performance → Post-1.0 Roadmap → Conclusion ✓",
+    "Comparative analysis covered: 5 comparable crates (grid, ndarray, image, embedded-graphics, Bevy) with trait design, layout support, no_std, indexing, and transforms compared in benchmark table ✓",
+    "Concrete recommendations provided: 10 recommendations with file:line references, before/after code snippets, and impact analysis ✓",
+    "Rust API Guidelines compliance reviewed: C-STRUCT-BOUNDS, C-SEALED, #[must_use], doc examples, no_std support, dual licensing all checked ✓",
+    "Safety analysis completed: TrustedSizeGrid, GridReadUnchecked, GridWriteUnchecked contracts documented with recommendations for improvement ✓"
+  ],
+  "residualRisks": [
+    "none"
+  ],
+  "noStagedFiles": true,
+  "diffSummary": "Created .matan/improve.md (29KB, 648 lines) containing comprehensive deep-dive review of grixy crate with architectural analysis, comparative landscape research, and 10 prioritized recommendations for pre-1.0 stabilization. Document is in .matan/ (gitignored personal notes directory) and is not staged for commit.",
+  "reviewFindings": [
+    "no blockers",
+    "crate is well-designed with solid trait hierarchy and no_std support",
+    "primary improvement areas: trait consolidation (GridIter redundancy), ergonomic indexing (GridIndex trait), clarity on GridDiff semantics, and documentation polish"
+  ],
+  "manualNotes": "Review is comprehensive and analysis-complete. Three high-priority recommendations identified: (1) consolidate GridIter into GridRead to reduce trait overhead, (2) add GridIndex trait for ergonomic Index[Pos] syntax across all grid types, (3) clarify GridDiff semantics with dedicated change types. Comparative analysis shows grixy occupies a unique sweet spot between simplicity (grid crate) and power (ndarray) with no other crate combining trait-first design, layout flexibility, and zero-cost transforms. Document ready for owner review and prioritization."
+}
+```
+
+---
+
+## Summary of Top 3 Recommendations
+
+1. **Consolidate `GridIter` into `GridRead`** (High): `GridIter` is a thin blanket impl adding `iter()`, `iter_with_pos()`, and `cells()` to all `GridRead + ExactSizeGrid` types. Moving these as default methods into `GridRead` eliminates trait redundancy and reduces cognitive overhead without losing functionality.
+
+2. **Introduce `GridIndex` trait for ergonomic `grid[Pos]` indexing** (High): Currently only `GridBuf` implements `Index<Pos>`. Generalizing via a `GridIndexable` trait or extending `GridRead` with associated indexable elements would allow user-defined types to support the intuitive `grid[pos]` syntax, matching expectations from crates like `image` and `ndarray`.
+
+3. **Clarify `GridDiff` semantics and ownership** (High): The current `diff()` implementation compares two grids and returns an iterator of self's elements that differ. Introducing a dedicated `GridChange` enum (e.g., `Added`, `Modified`) and clearer documentation would make the double-buffering pattern (common in game loops) more intuitive and less error-prone.
+
+---
+
+The review document has been successfully written to `/Users/matan/Developer/grixy/.matan/improve.md` and is ready for your review.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,7 +20,7 @@ Key points:
 - `cargo just semver-checks` to verify no accidental breaking changes
 - All public items must have doc examples
 - `#[must_use]` on all methods returning a value
-- Blanket trait impls over `GridRead + ExactSizeGrid` are preferred for extension traits (see `GridDiff`, `GridIter`)
+- Blanket trait impls over `GridRead + ExactSizeGrid` are preferred for extension traits (see `GridDiff`)
 
 ## Architecture
 
@@ -42,9 +42,9 @@ src/
 ├── ops.rs          # Module declarations for ops
 ├── ops/
 │   ├── base.rs     # GridBase, ExactSizeGrid traits
-│   ├── read.rs     # GridRead, GridIter traits (get, iter_rect, iter_rect_with_pos, etc.)
-│   ├── write.rs    # GridWrite trait (set, fill_*, clear_*)
-│   ├── diff.rs     # GridDiff trait (grid comparison via diff())
+│   ├── read.rs     # GridRead trait (get, iter_rect, iter_rect_with_pos, iter, iter_with_pos, cells)
+│   ├── write.rs    # GridWrite trait (set, fill/fill_with/fill_from_iter, clear_*)
+│   ├── diff.rs     # GridDiff trait + GridChange enum (grid comparison via diff_from())
 │   ├── draw.rs     # copy_rect() standalone function
 │   ├── layout.rs   # Re-exports from ixy (RowMajor, ColumnMajor, Block, Linear, Traversal)
 │   ├── cell.rs     # GridWrite for Cell/RefCell/UnsafeCell wrappers

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -46,7 +46,7 @@ src/
 │   ├── write.rs    # GridWrite trait (set, fill/fill_with/fill_from_iter, clear_*)
 │   ├── diff.rs     # GridDiff trait + GridChange enum (grid comparison via diff_from())
 │   ├── draw.rs     # copy_rect() standalone function
-│   ├── layout.rs   # Re-exports from ixy (RowMajor, ColumnMajor, Block, Linear, Traversal)
+│   ├── layout.rs   # Re-exports from ixy (RowMajor, ColumnMajor, Block, LinearLayout, Layout)
 │   ├── cell.rs     # GridWrite for Cell/RefCell/UnsafeCell wrappers
 │   ├── alloc.rs    # GridRead for Rc/Arc
 │   └── unchecked/  # GridReadUnchecked, GridWriteUnchecked, TrustedSizeGrid

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.6.0-alpha.8] - 2026-07-02
 
 ### Added
 
@@ -35,6 +35,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Removed
 
 - `GridIter` trait (folded into `GridRead`, see Changed)
+
+### Dependencies
+
+- Bumped `ixy` from `0.6.0-alpha.5` to `0.6.0-alpha.9`. Mechanical rename to follow ixy's own
+  breaking rename in that range:
+  - `layout::Traversal` → `layout::Layout`
+  - `layout::Linear` → `layout::LinearLayout`
+  - `LinearLayout::pos_to_index()`/`index_to_pos()`'s second parameter is now named `stride`
+    (was `width`); semantics unchanged
+  - No grixy-visible behavior change; `core::Size`/`core::Rect`/`HasSize` stay source-compatible
+    since ixy's new generic `Int` parameters default to `usize`, matching grixy's existing usage
 
 ## [0.6.0-alpha.6] - 2026-06-19
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,37 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- `GridChange<T>` enum (`Added`/`Modified`) describing a single cell's diff result
+- `VecGrid<T>`, `VecGridColMajor<T>` (alloc), `SliceGrid<'a, T>`, `SliceGridMut<'a, T>`
+  convenience aliases for common `GridBuf` instantiations, in `grixy::buf`
+- `Index<Pos>` impls for `Viewed<G>`, `Scaled<G>`, and `Blended<'_, G, F>` where the
+  source grid's `Element<'a> = &'a T`
+- Safety/unchecked-operations guide in the crate root docs (`grixy::lib`)
+- `GridBase` docs on when to implement it alone vs. with `ExactSizeGrid`
+
+### Changed
+
+- **Breaking:** `GridIter` trait removed; `iter()`, `iter_with_pos()`, and `cells()` are now
+  default methods on `GridRead`, gated on `Self: ExactSizeGrid`
+- **Breaking:** `GridDiff::diff()` renamed to `diff_from()` and now returns
+  `(Pos, GridChange<Element>)` instead of `(Pos, Element)`; cells beyond `other`'s bounds are now
+  reported as `GridChange::Added` instead of unconditionally treated as changed
+- **Breaking:** `GridWrite` methods renamed to follow `std::slice::fill`/`fill_with` convention:
+  - `fill_solid(value)` → `fill(value)`, `fill(f)` → `fill_with(f)`, `fill_iter(iter)` →
+    `fill_from_iter(iter)`
+  - `fill_rect_solid` → `fill_rect`, `fill_rect` (closure) → `fill_rect_with`, `fill_rect_iter` →
+    `fill_rect_from_iter`
+  - Unchecked equivalents in `GridWriteUnchecked` renamed to match
+- `GridRead::get()` is now `#[must_use]`
+
+### Removed
+
+- `GridIter` trait (folded into `GridRead`, see Changed)
+
 ## [0.6.0-alpha.6] - 2026-06-19
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -320,7 +320,7 @@ dependencies = [
 
 [[package]]
 name = "grixy"
-version = "0.6.0-alpha.7"
+version = "0.6.0-alpha.8"
 dependencies = [
  "bytemuck",
  "criterion",
@@ -409,9 +409,9 @@ checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
 
 [[package]]
 name = "ixy"
-version = "0.6.0-alpha.5"
+version = "0.6.0-alpha.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38c7555014e6b3d1416a5541b1a38f195b261eeded4e391cafb18484c8a293f4"
+checksum = "cf5db685a29892d524bda3513508e53a4949e452ad4112e9ee5bb13794337b59"
 dependencies = [
  "serde",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ rust-version = "1.87"
 documentation = "https://docs.rs/grixy"
 keywords = ["2d", "grid", "embedded", "no-std", "gamedev"]
 categories = ["game-development", "mathematics", "embedded", "no-std"]
-version = "0.6.0-alpha.7"
+version = "0.6.0-alpha.8"
 
 [lints.rust]
 missing_docs = "warn"
@@ -40,7 +40,7 @@ serde = ["dep:serde", "ixy/serde"]
 all-features = true
 
 [dependencies]
-ixy = { version = "0.6.0-alpha.5" }
+ixy = { version = "0.6.0-alpha.9" }
 serde = { version = "1.0", optional = true, features = ["derive"] }
 
 [dev-dependencies]

--- a/README.md
+++ b/README.md
@@ -25,12 +25,21 @@ Possible use-cases include:
 
 ## Features
 
-| Feature | Description | Default |
-|---------|-------------|---------|
-| `alloc` | `Vec`-backed grid buffers (`new`, `new_filled`, `resize`, etc.) | No |
-| `buffer` | `GridBuf` type and related grid types | No |
-| `cell` | `GridWrite` impls for `Cell`, `RefCell`, `UnsafeCell` | No |
-| `serde` | `Serialize`/`Deserialize` for `GridBuf` and `GridError` | No |
+| Feature | Enables | Default | Depends on |
+|---------|---------|---------|------------|
+| `alloc` | `Vec`-backed grid buffers (`new`, `new_filled`, `resize`, etc.), `GridRead` for `Rc`/`Arc`/`Box` | No | (none) |
+| `buffer` | `GridBuf` type and related grid types (`GridBits`, aliases) | No | (none) |
+| `cell` | `GridWrite` impls for `Cell`, `RefCell`, `UnsafeCell` | No | (none) |
+| `serde` | `Serialize`/`Deserialize` for `GridBuf` and `GridError` | No | `buffer` (soft) |
+
+### Common combinations
+
+- **Library code / trait definitions only**: no features. Depend on `GridRead`/`GridWrite` without
+  pulling in a concrete buffer type.
+- **Game development / general use**: `buffer` + `alloc`, for `Vec`-backed `GridBuf` and the
+  `VecGrid`/`VecGridColMajor` aliases.
+- **Embedded / `no_std` without an allocator**: `buffer` alone, using `GridBuf` over `&[T]`/`&mut
+  [T]` (see `SliceGrid`/`SliceGridMut`) or a custom fixed-size buffer type.
 
 ## Quick start
 
@@ -42,10 +51,13 @@ let mut grid = GridBuf::<u8, _, _>::new(5, 5);
 grid[Pos::new(0, 0)] = 42;
 assert_eq!(grid.get(Pos::new(0, 0)), Some(&42));
 
-// Compare two grids with diff().
+// Compare two grids with diff_from().
 let other = GridBuf::new_filled(5, 5, 0u8);
-let changes: Vec<_> = grid.diff(&other).collect();
-assert_eq!(changes, [(Pos::new(0, 0), &42u8)]);
+let changes: Vec<_> = grid.diff_from(&other).collect();
+assert_eq!(
+    changes,
+    [(Pos::new(0, 0), GridChange::Modified { from: &0u8, to: &42u8 })]
+);
 
 // Resize preserving content overlap.
 grid.resize(10, 10);

--- a/examples/z-order-layout.rs
+++ b/examples/z-order-layout.rs
@@ -3,7 +3,7 @@
 #![allow(missing_docs)]
 
 use grixy::{
-    ops::layout::{Linear, Traversal},
+    ops::layout::{Layout, LinearLayout},
     prelude::*,
 };
 
@@ -30,7 +30,7 @@ const fn unspread_bits(n: u32) -> u32 {
     x
 }
 
-impl Traversal for ZOrderCurve {
+impl Layout for ZOrderCurve {
     fn iter_pos<T: ixy::int::Int>(rect: ixy::Rect<T>) -> impl Iterator<Item = ixy::Pos<T>> {
         RowMajor::iter_pos(rect)
     }
@@ -43,8 +43,8 @@ impl Traversal for ZOrderCurve {
     }
 }
 
-impl Linear for ZOrderCurve {
-    fn pos_to_index(pos: Pos, _width: usize) -> usize {
+impl LinearLayout for ZOrderCurve {
+    fn pos_to_index(pos: Pos, _stride: usize) -> usize {
         let x: u16 = pos.x.try_into().expect("Coordinates must fit in a u16");
         let y: u16 = pos.y.try_into().expect("Coordinates must fit in a u16");
         let x: u32 = x.into();
@@ -56,7 +56,7 @@ impl Linear for ZOrderCurve {
         index as usize
     }
 
-    fn index_to_pos(index: usize, _width: usize) -> Pos {
+    fn index_to_pos(index: usize, _stride: usize) -> Pos {
         let index: u32 = index.try_into().expect("Index must fit in a u32");
         let x = unspread_bits(index);
         let y = unspread_bits(index >> 1);

--- a/src/buf.rs
+++ b/src/buf.rs
@@ -45,9 +45,9 @@ mod impl_slice;
 /// ## Layout
 ///
 /// The grid is stored in a linear buffer, with elements accessed in an order defined by
-/// [`Traversal`].
+/// [`Layout`].
 ///
-/// [`Traversal`]: layout::Traversal
+/// [`Layout`]: layout::Layout
 #[derive(Debug, Clone)]
 pub struct GridBuf<T, B, L> {
     buffer: B,
@@ -59,7 +59,7 @@ pub struct GridBuf<T, B, L> {
 
 impl<T, B, L> GridBuf<T, B, L>
 where
-    L: layout::Linear,
+    L: layout::LinearLayout,
 {
     /// Consumes the `GridBuf`, returning the underlying buffer, width, and height.
     #[must_use]
@@ -72,7 +72,7 @@ where
     pub fn get_mut(&mut self, pos: Pos) -> Option<&mut T>
     where
         B: AsMut<[T]>,
-        L: layout::Linear,
+        L: layout::LinearLayout,
     {
         if self.contains(pos) {
             let idx = L::pos_to_index(pos, self.width);
@@ -85,7 +85,7 @@ where
 
 impl<T, B, L> Index<Pos> for GridBuf<T, B, L>
 where
-    L: layout::Linear,
+    L: layout::LinearLayout,
     B: AsRef<[T]>,
 {
     type Output = T;
@@ -97,7 +97,7 @@ where
 
 impl<T, B, L> IndexMut<Pos> for GridBuf<T, B, L>
 where
-    L: layout::Linear,
+    L: layout::LinearLayout,
     B: AsRef<[T]> + AsMut<[T]>,
 {
     fn index_mut(&mut self, index: Pos) -> &mut Self::Output {
@@ -109,7 +109,7 @@ impl<T, B, L> fmt::Display for GridBuf<T, B, L>
 where
     T: fmt::Display + Default + PartialEq,
     B: AsRef<[T]>,
-    L: layout::Linear,
+    L: layout::LinearLayout,
 {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         for row in 0..self.height {

--- a/src/buf.rs
+++ b/src/buf.rs
@@ -23,6 +23,11 @@ use core::{
 
 pub mod bits;
 
+mod aliases;
+pub use aliases::{SliceGrid, SliceGridMut};
+#[cfg(feature = "alloc")]
+pub use aliases::{VecGrid, VecGridColMajor};
+
 // TRAIT IMPLS -------------------------------------------------------------------------------------
 
 use crate::ops::ExactSizeGrid as _;
@@ -205,10 +210,10 @@ mod tests {
     }
 
     #[test]
-    fn fill_rect_iter_unchecked() {
+    fn fill_rect_from_iter_unchecked() {
         let mut grid = GridBuf::<_, _, RowMajor>::new(3, 3);
         unsafe {
-            grid.fill_rect_iter_unchecked(Rect::from_ltwh(0, 0, 2, 2), vec![1, 2, 3, 4]);
+            grid.fill_rect_from_iter_unchecked(Rect::from_ltwh(0, 0, 2, 2), vec![1, 2, 3, 4]);
         }
         #[rustfmt::skip]
         assert_eq!(grid.buffer.as_ref() as &[i32], &[
@@ -219,10 +224,10 @@ mod tests {
     }
 
     #[test]
-    fn fill_rect_solid_unchecked() {
+    fn fill_rect_unchecked() {
         let mut grid = GridBuf::<_, _, RowMajor>::new(3, 3);
         unsafe {
-            grid.fill_rect_solid_unchecked(Rect::from_ltwh(0, 0, 2, 2), 42);
+            grid.fill_rect_unchecked(Rect::from_ltwh(0, 0, 2, 2), 42);
         }
         #[rustfmt::skip]
         assert_eq!(grid.buffer.as_ref() as &[i32], &[

--- a/src/buf/aliases.rs
+++ b/src/buf/aliases.rs
@@ -1,0 +1,69 @@
+//! Convenience type aliases for common [`GridBuf`](crate::buf::GridBuf) instantiations.
+//!
+//! `GridBuf<T, B, L>` is fully generic over its buffer and layout, which is powerful but verbose
+//! for the common cases. These aliases spell out the usual combinations.
+
+use crate::buf::GridBuf;
+use crate::ops::layout::RowMajor;
+
+/// A slice-backed, row-major grid borrowing an immutable `&[T]`.
+///
+/// Backed by `GridBuf<T, &[T], RowMajor>`; construct with
+/// [`GridBuf::from_buffer`](crate::buf::GridBuf::from_buffer). Works without the `alloc` feature,
+/// including over stack-allocated arrays.
+///
+/// ```rust
+/// use grixy::{buf::SliceGrid, core::Pos, ops::GridRead as _};
+///
+/// let data = [1, 2, 3, 4, 5, 6];
+/// let grid = SliceGrid::from_buffer(&data[..], 3);
+/// assert_eq!(grid.get(Pos::new(0, 0)), Some(&1));
+/// ```
+pub type SliceGrid<'a, T> = GridBuf<T, &'a [T], RowMajor>;
+
+/// A slice-backed, row-major grid borrowing a mutable `&mut [T]`.
+///
+/// Backed by `GridBuf<T, &mut [T], RowMajor>`; construct with
+/// [`GridBuf::from_buffer`](crate::buf::GridBuf::from_buffer). Works without the `alloc` feature,
+/// including over stack-allocated arrays.
+///
+/// ```rust
+/// use grixy::{buf::SliceGridMut, core::Pos, ops::GridWrite as _};
+///
+/// let mut data = [0; 6];
+/// let mut grid = SliceGridMut::from_buffer(&mut data[..], 3);
+/// grid.set(Pos::new(0, 0), 42).unwrap();
+/// ```
+pub type SliceGridMut<'a, T> = GridBuf<T, &'a mut [T], RowMajor>;
+
+#[cfg(feature = "alloc")]
+mod alloc_aliases {
+    extern crate alloc;
+
+    use super::{GridBuf, RowMajor};
+    use crate::ops::layout::ColumnMajor;
+    use alloc::vec::Vec;
+
+    /// A `Vec`-backed, row-major grid.
+    ///
+    /// Backed by `GridBuf<T, Vec<T>, RowMajor>`; construct with
+    /// [`GridBuf::new`](crate::buf::GridBuf::new) or
+    /// [`GridBuf::new_filled`](crate::buf::GridBuf::new_filled).
+    ///
+    /// ```rust
+    /// use grixy::{buf::VecGrid, core::Pos, ops::GridRead as _};
+    ///
+    /// let grid: VecGrid<u8> = VecGrid::new_filled(3, 3, 42);
+    /// assert_eq!(grid.get(Pos::new(1, 1)), Some(&42));
+    /// ```
+    pub type VecGrid<T> = GridBuf<T, Vec<T>, RowMajor>;
+
+    /// A `Vec`-backed, column-major grid.
+    ///
+    /// Backed by `GridBuf<T, Vec<T>, ColumnMajor>`; construct with
+    /// [`GridBuf::new_filled_with_layout`](crate::buf::GridBuf::new_filled_with_layout).
+    pub type VecGridColMajor<T> = GridBuf<T, Vec<T>, ColumnMajor>;
+}
+
+#[cfg(feature = "alloc")]
+pub use alloc_aliases::{VecGrid, VecGridColMajor};

--- a/src/buf/bits.rs
+++ b/src/buf/bits.rs
@@ -35,14 +35,14 @@ extern crate alloc;
 /// ## Layout
 ///
 /// The grid is stored in a linear buffer, with elements accessed in an order defined by
-/// [`Traversal`].
+/// [`Layout`].
 ///
-/// [`Traversal`]: layout::Traversal
+/// [`Layout`]: layout::Layout
 #[derive(Debug, Clone)]
 pub struct GridBits<T, B, L>
 where
     T: BitOps,
-    L: layout::Linear,
+    L: layout::LinearLayout,
 {
     buffer: B,
     width: usize,
@@ -55,7 +55,7 @@ impl<T, B, L> GridBits<T, B, L>
 where
     T: BitOps,
     B: AsRef<[T]>,
-    L: layout::Linear,
+    L: layout::LinearLayout,
 {
     /// Returns a grid from an existing buffer with a given width in columns.
     ///
@@ -129,7 +129,7 @@ where
 impl<T, L> GridBits<T, alloc::vec::Vec<T>, L>
 where
     T: BitOps,
-    L: layout::Linear,
+    L: layout::LinearLayout,
 {
     /// Creates a new grid with the specified width, height, and layout, filled with the default value.
     ///
@@ -154,7 +154,7 @@ impl<T, B, L> AsRef<[T]> for GridBits<T, B, L>
 where
     T: BitOps,
     B: AsRef<[T]>,
-    L: layout::Linear,
+    L: layout::LinearLayout,
 {
     fn as_ref(&self) -> &[T] {
         self.buffer.as_ref()
@@ -165,7 +165,7 @@ impl<T, B, L> AsMut<[T]> for GridBits<T, B, L>
 where
     T: BitOps,
     B: AsMut<[T]>,
-    L: layout::Linear,
+    L: layout::LinearLayout,
 {
     fn as_mut(&mut self) -> &mut [T] {
         self.buffer.as_mut()
@@ -176,7 +176,7 @@ impl<T, B, L> GridBits<T, B, L>
 where
     T: BitOps,
     B: AsRef<[T]>,
-    L: layout::Linear,
+    L: layout::LinearLayout,
 {
     /// Consumes the `GridBits`, returning the underlying buffer, width, and height.
     #[must_use]
@@ -198,7 +198,7 @@ impl<T, B, L> GridReadUnchecked for GridBits<T, B, L>
 where
     T: BitOps,
     B: AsRef<[T]>,
-    L: layout::Linear,
+    L: layout::LinearLayout,
 {
     type Element<'a>
         = bool
@@ -237,7 +237,7 @@ impl<T, B, L> GridWriteUnchecked for GridBits<T, B, L>
 where
     T: BitOps,
     B: AsMut<[T]>,
-    L: layout::Linear,
+    L: layout::LinearLayout,
 {
     type Element = bool;
     type Layout = L;
@@ -258,7 +258,7 @@ impl<T, B, L> GridBase for GridBits<T, B, L>
 where
     T: BitOps,
     B: AsRef<[T]>,
-    L: layout::Linear,
+    L: layout::LinearLayout,
 {
     fn size_hint(&self) -> (crate::prelude::Size, Option<crate::prelude::Size>) {
         let size = Size::new(self.width, self.height);
@@ -270,7 +270,7 @@ impl<T, B, L> ExactSizeGrid for GridBits<T, B, L>
 where
     T: BitOps,
     B: AsRef<[T]>,
-    L: layout::Linear,
+    L: layout::LinearLayout,
 {
     fn width(&self) -> usize {
         self.width
@@ -285,7 +285,7 @@ unsafe impl<T, B, L> TrustedSizeGrid for GridBits<T, B, L>
 where
     T: BitOps,
     B: AsRef<[T]>,
-    L: layout::Linear,
+    L: layout::LinearLayout,
 {
 }
 
@@ -293,7 +293,7 @@ impl<T, B, L> Index<Pos> for GridBits<T, B, L>
 where
     T: BitOps,
     B: AsRef<[T]>,
-    L: layout::Linear,
+    L: layout::LinearLayout,
 {
     type Output = bool;
 

--- a/src/buf/impl_grid.rs
+++ b/src/buf/impl_grid.rs
@@ -10,7 +10,7 @@ use crate::{
 
 impl<T, B, L> GridBase for GridBuf<T, B, L>
 where
-    L: layout::Linear,
+    L: layout::LinearLayout,
 {
     fn size_hint(&self) -> (crate::prelude::Size, Option<crate::prelude::Size>) {
         let size = Size::new(self.width, self.height);
@@ -20,7 +20,7 @@ where
 
 impl<T, B, L> ExactSizeGrid for GridBuf<T, B, L>
 where
-    L: layout::Linear,
+    L: layout::LinearLayout,
 {
     fn width(&self) -> usize {
         self.width
@@ -35,12 +35,12 @@ where
 // and those dimensions match `ExactSizeGrid::width()`/`height()`. The buffer length is always
 // `width * height` (enforced by `from_buffer` and constructors), so unchecked indexing into
 // the buffer at `L::pos_to_index(pos, width)` for any pos within `(0..width, 0..height)` is safe.
-unsafe impl<T, B, L> TrustedSizeGrid for GridBuf<T, B, L> where L: layout::Linear {}
+unsafe impl<T, B, L> TrustedSizeGrid for GridBuf<T, B, L> where L: layout::LinearLayout {}
 
 impl<T, B, L> GridReadUnchecked for GridBuf<T, B, L>
 where
     B: AsRef<[T]>,
-    L: layout::Linear,
+    L: layout::LinearLayout,
 {
     type Element<'a>
         = &'a T
@@ -82,7 +82,7 @@ where
 impl<T, B, L> GridWriteUnchecked for GridBuf<T, B, L>
 where
     B: AsMut<[T]>,
-    L: layout::Linear,
+    L: layout::LinearLayout,
 {
     type Element = T;
     type Layout = L;

--- a/src/buf/impl_grid.rs
+++ b/src/buf/impl_grid.rs
@@ -94,7 +94,7 @@ where
         unsafe { *self.buffer.as_mut().get_unchecked_mut(index) = value }
     }
 
-    unsafe fn fill_rect_iter_unchecked(
+    unsafe fn fill_rect_from_iter_unchecked(
         &mut self,
         bounds: crate::core::Rect,
         iter: impl IntoIterator<Item = Self::Element>,
@@ -121,7 +121,7 @@ where
         }
     }
 
-    unsafe fn fill_rect_solid_unchecked(&mut self, bounds: crate::core::Rect, value: Self::Element)
+    unsafe fn fill_rect_unchecked(&mut self, bounds: crate::core::Rect, value: Self::Element)
     where
         Self::Element: Copy,
     {

--- a/src/buf/impl_new.rs
+++ b/src/buf/impl_new.rs
@@ -7,7 +7,7 @@ use core::marker::PhantomData;
 impl<T, B, L> GridBuf<T, B, L>
 where
     B: AsRef<[T]>,
-    L: layout::Linear,
+    L: layout::LinearLayout,
 {
     /// Returns a grid from an existing buffer with a given width in columns.
     ///
@@ -111,7 +111,7 @@ impl<T> GridBuf<T, alloc::vec::Vec<T>, layout::RowMajor> {
 #[cfg(feature = "alloc")]
 impl<T, L> GridBuf<T, alloc::vec::Vec<T>, L>
 where
-    L: layout::Linear,
+    L: layout::LinearLayout,
 {
     /// Creates a new grid with the specified width and height, filled with a default value.
     ///
@@ -122,7 +122,7 @@ where
     pub fn new_filled_with_layout(width: usize, height: usize, value: T) -> Self
     where
         T: Copy,
-        L: layout::Linear,
+        L: layout::LinearLayout,
     {
         let buffer = alloc::vec![value; width * height];
         Self {

--- a/src/buf/impl_resize.rs
+++ b/src/buf/impl_resize.rs
@@ -7,7 +7,7 @@ use crate::{buf::GridBuf, core::Pos, ops::layout};
 impl<T, L> GridBuf<T, alloc::vec::Vec<T>, L>
 where
     T: Clone + Default,
-    L: layout::Linear,
+    L: layout::LinearLayout,
 {
     /// Resizes the grid to the new dimensions.
     ///

--- a/src/buf/impl_serde.rs
+++ b/src/buf/impl_serde.rs
@@ -18,7 +18,7 @@ impl<T, B, L> Serialize for GridBuf<T, B, L>
 where
     T: Serialize,
     B: AsRef<[T]>,
-    L: layout::Linear,
+    L: layout::LinearLayout,
 {
     fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         use serde::ser::SerializeStruct;
@@ -34,7 +34,7 @@ where
 impl<'de, T, L> Deserialize<'de> for GridBuf<T, alloc::vec::Vec<T>, L>
 where
     T: Deserialize<'de> + Default + Copy,
-    L: layout::Linear,
+    L: layout::LinearLayout,
 {
     fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
         enum Field {
@@ -75,7 +75,7 @@ where
         impl<'de, T, L> Visitor<'de> for GridBufVisitor<T, L>
         where
             T: Deserialize<'de> + Default + Copy,
-            L: layout::Linear,
+            L: layout::LinearLayout,
         {
             type Value = GridBuf<T, alloc::vec::Vec<T>, L>;
 

--- a/src/buf/impl_slice.rs
+++ b/src/buf/impl_slice.rs
@@ -3,7 +3,7 @@ use crate::{buf::GridBuf, ops::layout};
 impl<T, B, L> AsRef<[T]> for GridBuf<T, B, L>
 where
     B: AsRef<[T]>,
-    L: layout::Linear,
+    L: layout::LinearLayout,
 {
     fn as_ref(&self) -> &[T] {
         self.buffer.as_ref()
@@ -13,7 +13,7 @@ where
 impl<T, B, L> AsMut<[T]> for GridBuf<T, B, L>
 where
     B: AsMut<[T]>,
-    L: layout::Linear,
+    L: layout::LinearLayout,
 {
     fn as_mut(&mut self) -> &mut [T] {
         self.buffer.as_mut()

--- a/src/core.rs
+++ b/src/core.rs
@@ -20,6 +20,11 @@ pub type Rect = ixy::Rect<usize>;
 pub type Size = ixy::Size;
 
 /// An error type for operations on or creating a `Grid`.
+///
+/// Marked `#[non_exhaustive]` even though it currently has a single variant: grid operations are
+/// expected to grow additional failure modes over time (for example, buffer/layout mismatches on
+/// construction), and this lets those be added without a breaking change to downstream `match`
+/// expressions.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[non_exhaustive]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -50,6 +50,82 @@
 //! ### `cell`
 //!
 //! Provides `GridWrite` when a mutable cell is wrapping a `GridWrite` type.
+//!
+//! ## Safety and unchecked operations
+//!
+//! Grixy provides unchecked variants ([`GridReadUnchecked`], [`GridWriteUnchecked`]) alongside
+//! the checked [`GridRead`]/[`GridWrite`] traits, for performance-critical code that wants to
+//! skip per-call bounds checks (see [`ops::unchecked`]).
+//!
+//! The unchecked traits are opt-in and unsafe to call directly: every method requires the caller
+//! to prove the position (or every position in a rectangle) is in-bounds. What makes them usable
+//! from *safe* code is [`TrustedSizeGrid`]: implementing this unsafe marker trait is a promise
+//! that `size_hint()` reports the grid's true dimensions, and unlocks blanket impls that turn
+//! `GridReadUnchecked + TrustedSizeGrid` into a safe [`GridRead`] (and likewise for writes) by
+//! doing the bounds check once, in the blanket impl, before dispatching to the unchecked method.
+//!
+//! In short:
+//!
+//! 1. Implement `GridReadUnchecked`/`GridWriteUnchecked` with the actual (unchecked) access logic.
+//! 2. Implement `unsafe impl TrustedSizeGrid for MyGrid {}` once you've verified `size_hint()` is
+//!    accurate.
+//! 3. `GridRead`/`GridWrite` are now implemented automatically, and bounds-checked for you.
+//!
+//! **Never implement `TrustedSizeGrid` for a type whose reported size can be wrong.** Doing so
+//! nullifies the safety guarantees of every blanket impl built on top of it, and can lead to
+//! reading or writing out of bounds, which is undefined behavior.
+//!
+//! ### Example: a custom grid with unchecked access
+//!
+//! ```rust
+//! use grixy::{
+//!     core::{Pos, Rect, Size},
+//!     ops::{
+//!         ExactSizeGrid, GridBase, GridRead as _,
+//!         unchecked::{GridReadUnchecked, TrustedSizeGrid},
+//!     },
+//! };
+//!
+//! struct FixedGrid {
+//!     cells: [u8; 9], // Always 3x3.
+//! }
+//!
+//! impl GridBase for FixedGrid {
+//!     fn size_hint(&self) -> (Size, Option<Size>) {
+//!         let size = Size::new(3, 3);
+//!         (size, Some(size))
+//!     }
+//! }
+//!
+//! impl ExactSizeGrid for FixedGrid {
+//!     fn width(&self) -> usize { 3 }
+//!     fn height(&self) -> usize { 3 }
+//! }
+//!
+//! impl GridReadUnchecked for FixedGrid {
+//!     type Element<'a> = u8;
+//!     type Layout = grixy::ops::layout::RowMajor;
+//!
+//!     unsafe fn get_unchecked(&self, pos: Pos) -> u8 {
+//!         // SAFETY: caller guarantees `pos` is within the 3x3 grid.
+//!         unsafe { *self.cells.get_unchecked(pos.y * 3 + pos.x) }
+//!     }
+//! }
+//!
+//! // SAFETY: `size_hint()` always reports the true, fixed 3x3 size.
+//! unsafe impl TrustedSizeGrid for FixedGrid {}
+//!
+//! // `GridRead` now comes for free, with bounds checking handled by the blanket impl.
+//! let grid = FixedGrid { cells: [0, 1, 2, 3, 4, 5, 6, 7, 8] };
+//! assert_eq!(grid.get(Pos::new(1, 1)), Some(4));
+//! assert_eq!(grid.get(Pos::new(3, 3)), None); // Bounds-checked, not UB.
+//! ```
+//!
+//! [`GridReadUnchecked`]: ops::unchecked::GridReadUnchecked
+//! [`GridWriteUnchecked`]: ops::unchecked::GridWriteUnchecked
+//! [`TrustedSizeGrid`]: ops::unchecked::TrustedSizeGrid
+//! [`GridRead`]: ops::GridRead
+//! [`GridWrite`]: ops::GridWrite
 
 #![cfg_attr(docsrs, feature(doc_cfg))]
 #![no_std]

--- a/src/ops.rs
+++ b/src/ops.rs
@@ -71,7 +71,7 @@ mod read;
 mod write;
 
 pub use base::{ExactSizeGrid, GridBase};
-pub use diff::GridDiff;
+pub use diff::{GridChange, GridDiff};
 pub use draw::copy_rect;
-pub use read::{GridIter, GridRead};
+pub use read::GridRead;
 pub use write::GridWrite;

--- a/src/ops/alloc.rs
+++ b/src/ops/alloc.rs
@@ -45,6 +45,12 @@ use alloc::{rc::Rc, sync::Arc};
 impl_grid_read!(Arc);
 impl_grid_read!(Rc);
 
+// Note: `Box<T>` intentionally does *not* get a `GridRead` impl here. `Box` is `#[fundamental]`,
+// which means the compiler can't rule out a downstream `impl GridReadUnchecked + TrustedSizeGrid
+// for Box<X>` overlapping with the blanket `impl<T: GridReadUnchecked + TrustedSizeGrid> GridRead
+// for T` in `ops::unchecked::read`. `Rc`/`Arc` aren't fundamental, so they don't hit this. If you
+// need `GridRead` through a `Box`, deref it (`&*boxed_grid`) or use `Rc`/`Arc` instead.
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/ops/base.rs
+++ b/src/ops/base.rs
@@ -1,6 +1,31 @@
 use crate::core::{Pos, Rect, Size};
 
 /// A base trait for grids.
+///
+/// # Implementing `GridBase`
+///
+/// Implement `GridBase` alone (without [`ExactSizeGrid`]) when:
+///
+/// - the grid's size is unknown at compile time and cannot be determined cheaply at runtime,
+///   for example a lazily generated or effectively infinite grid (procedural terrain, a fractal,
+///   a stream of tiles);
+///   
+/// - computing an exact size would be expensive relative to the operations you actually need
+///   (e.g. a grid backed by a sparse map where counting occupied cells is O(n)).
+///
+/// A `GridBase`-only grid can still implement [`GridRead`](crate::ops::GridRead) and be read from
+/// via `get()`/`iter_rect()`; it just can't provide the whole-grid conveniences that require
+/// knowing the bounds up front.
+///
+/// Implement [`ExactSizeGrid`] in addition when:
+///
+/// - the grid's size is known precisely and cheaply (`O(1)`);
+/// - you want callers to use the whole-grid convenience methods on
+///   [`GridRead`](crate::ops::GridRead) (`iter()`, `iter_with_pos()`, `cells()`) and
+///   [`GridDiff`](crate::ops::GridDiff) (`diff_from()`), which are gated on `ExactSizeGrid`;
+/// - you want to implement [`TrustedSizeGrid`](crate::ops::unchecked::TrustedSizeGrid) to unlock
+///   unchecked, bounds-check-free access via [`GridReadUnchecked`](crate::ops::unchecked::GridReadUnchecked)
+///   and [`GridWriteUnchecked`](crate::ops::unchecked::GridWriteUnchecked).
 pub trait GridBase {
     /// Returns the size of the grid, if known.
     ///

--- a/src/ops/cell.rs
+++ b/src/ops/cell.rs
@@ -20,19 +20,23 @@ macro_rules! impl_grid_write {
                 self.get_mut().set(pos, value)
             }
 
-            fn fill_rect(&mut self, bounds: Rect, f: impl FnMut(Pos) -> Self::Element) {
-                self.get_mut().fill_rect(bounds, f);
+            fn fill_rect_with(&mut self, bounds: Rect, f: impl FnMut(Pos) -> Self::Element) {
+                self.get_mut().fill_rect_with(bounds, f);
             }
 
-            fn fill_rect_iter(&mut self, dst: Rect, iter: impl IntoIterator<Item = Self::Element>) {
-                self.get_mut().fill_rect_iter(dst, iter);
+            fn fill_rect_from_iter(
+                &mut self,
+                dst: Rect,
+                iter: impl IntoIterator<Item = Self::Element>,
+            ) {
+                self.get_mut().fill_rect_from_iter(dst, iter);
             }
 
-            fn fill_rect_solid(&mut self, dst: Rect, value: Self::Element)
+            fn fill_rect(&mut self, dst: Rect, value: Self::Element)
             where
                 Self::Element: Copy,
             {
-                self.get_mut().fill_rect_solid(dst, value);
+                self.get_mut().fill_rect(dst, value);
             }
         }
     };
@@ -83,9 +87,9 @@ mod tests {
 
     fn test_grid_write<'a>(grid: &mut (impl GridWrite<Element = u8> + 'a)) {
         grid.set(Pos::new(1, 1), 42).unwrap();
-        grid.fill_rect(Rect::from_ltwh(0, 0, 3, 3), |_| 0);
-        grid.fill_rect_iter(Rect::from_ltwh(0, 0, 3, 3), [1, 2, 3]);
-        grid.fill_rect_solid(Rect::from_ltwh(0, 0, 3, 3), 99);
+        grid.fill_rect_with(Rect::from_ltwh(0, 0, 3, 3), |_| 0);
+        grid.fill_rect_from_iter(Rect::from_ltwh(0, 0, 3, 3), [1, 2, 3]);
+        grid.fill_rect(Rect::from_ltwh(0, 0, 3, 3), 99);
     }
 
     // #[test]

--- a/src/ops/diff.rs
+++ b/src/ops/diff.rs
@@ -3,6 +3,40 @@ use crate::{
     ops::{ExactSizeGrid, GridRead, layout::Traversal as _},
 };
 
+/// Describes how a single cell differs between two grids, as yielded by [`GridDiff::diff_from`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum GridChange<T> {
+    /// The cell exists in the grid being diffed, but has no counterpart in `other`.
+    ///
+    /// This happens when `other` is smaller than `self`, so a position that's valid in `self`
+    /// falls outside `other`'s bounds.
+    Added(T),
+
+    /// The cell exists in both grids, but the values differ.
+    ///
+    /// `from` is `other`'s value (the previous/baseline state), `to` is `self`'s value (the
+    /// current state).
+    Modified {
+        /// The value in `other` (the previous state).
+        from: T,
+        /// The value in `self` (the current state).
+        to: T,
+    },
+}
+
+impl<T> GridChange<T> {
+    /// Returns the "current" value of this change, i.e. `self`'s value.
+    ///
+    /// For [`Added`](GridChange::Added) this is the added value; for
+    /// [`Modified`](GridChange::Modified) this is `to`.
+    #[must_use]
+    pub fn current(&self) -> &T {
+        match self {
+            GridChange::Added(value) | GridChange::Modified { to: value, .. } => value,
+        }
+    }
+}
+
 /// Extension trait for comparing two grids.
 ///
 /// Automatically implemented for all types that implement [`GridRead`] and [`ExactSizeGrid`].
@@ -16,19 +50,29 @@ use crate::{
 /// let mut b = GridBuf::new_filled(3, 3, 0u8);
 /// b[Pos::new(1, 1)] = 42;
 ///
-/// let changed: Vec<_> = a.diff(&b).collect();
-/// assert_eq!(changed, [(Pos::new(1, 1), &0u8)]);
+/// let changed: Vec<_> = b.diff_from(&a).collect();
+/// assert_eq!(
+///     changed,
+///     [(Pos::new(1, 1), GridChange::Modified { from: &0u8, to: &42u8 })]
+/// );
 /// ```
 pub trait GridDiff: GridRead + ExactSizeGrid {
-    /// Returns an iterator over positions where `self` differs from `other`.
+    /// Returns an iterator over cells where `self` differs from `other`.
     ///
-    /// Elements are compared with [`PartialEq`]. Positions are yielded in the
-    /// traversal order defined by `Self::Layout`.
+    /// `self` is the current/new state, `other` is the previous/baseline state — matching the
+    /// common double-buffering pattern in game loops, where you diff this frame's grid against
+    /// last frame's to figure out what changed.
     ///
-    /// If the grids have different dimensions, all positions in `self` are
-    /// considered changed. This matches the rg double-buffering contract: resize
-    /// both buffers before diffing.
-    fn diff<'a>(&'a self, other: &'a Self) -> impl Iterator<Item = (Pos, Self::Element<'a>)> + 'a
+    /// Elements are compared with [`PartialEq`]. Positions are yielded in the traversal order
+    /// defined by `Self::Layout`.
+    ///
+    /// If `other` is smaller than `self`, positions that fall outside `other`'s bounds are
+    /// yielded as [`GridChange::Added`]. Positions inside both grids are yielded as
+    /// [`GridChange::Modified`] when they differ, and omitted when they're equal.
+    fn diff_from<'a>(
+        &'a self,
+        other: &'a Self,
+    ) -> impl Iterator<Item = (Pos, GridChange<Self::Element<'a>>)> + 'a
     where
         Self::Element<'a>: PartialEq;
 }
@@ -37,22 +81,28 @@ impl<G> GridDiff for G
 where
     G: GridRead + ExactSizeGrid,
 {
-    fn diff<'a>(&'a self, other: &'a Self) -> impl Iterator<Item = (Pos, Self::Element<'a>)> + 'a
+    fn diff_from<'a>(
+        &'a self,
+        other: &'a Self,
+    ) -> impl Iterator<Item = (Pos, GridChange<Self::Element<'a>>)> + 'a
     where
         Self::Element<'a>: PartialEq,
     {
-        let same_size = self.width() == other.width() && self.height() == other.height();
         let full_rect = Rect::from_ltwh(0, 0, self.width(), self.height());
 
         Self::Layout::iter_pos(full_rect).filter_map(move |pos| {
             let current = self.get(pos)?;
-            if same_size {
-                let previous = other.get(pos)?;
-                if current == previous {
-                    return None;
-                }
+            match other.get(pos) {
+                Some(previous) if previous == current => None,
+                Some(previous) => Some((
+                    pos,
+                    GridChange::Modified {
+                        from: previous,
+                        to: current,
+                    },
+                )),
+                None => Some((pos, GridChange::Added(current))),
             }
-            Some((pos, current))
         })
     }
 }
@@ -61,44 +111,62 @@ where
 mod tests {
     extern crate alloc;
 
-    use crate::{buf::GridBuf, core::Pos, ops::GridDiff as _};
+    use crate::{
+        buf::GridBuf,
+        core::Pos,
+        ops::{GridChange, GridDiff as _},
+    };
     use alloc::vec::Vec;
 
     #[test]
     fn diff_same_grid() {
         let a = GridBuf::new_filled(3, 3, 0u8);
         let b = GridBuf::new_filled(3, 3, 0u8);
-        let changed: Vec<_> = a.diff(&b).collect();
+        let changed: Vec<_> = a.diff_from(&b).collect();
         assert!(changed.is_empty());
     }
 
     #[test]
     fn diff_one_changed_cell() {
-        let a = GridBuf::new_filled(3, 3, 0u8);
         let mut b = GridBuf::new_filled(3, 3, 0u8);
+        let a = GridBuf::new_filled(3, 3, 0u8);
         b[Pos::new(1, 1)] = 42;
 
-        let changed: Vec<_> = a.diff(&b).collect();
-        assert_eq!(changed, [(Pos::new(1, 1), &0u8)]);
+        let changed: Vec<_> = b.diff_from(&a).collect();
+        assert_eq!(
+            changed,
+            [(
+                Pos::new(1, 1),
+                GridChange::Modified {
+                    from: &0u8,
+                    to: &42u8
+                }
+            )]
+        );
     }
 
     #[test]
     fn diff_all_changed() {
-        let a = GridBuf::new_filled(3, 3, 0u8);
-        let b = GridBuf::new_filled(3, 3, 1u8);
+        let a = GridBuf::new_filled(3, 3, 1u8);
+        let b = GridBuf::new_filled(3, 3, 0u8);
 
-        let changed: Vec<_> = a.diff(&b).collect();
+        let changed: Vec<_> = a.diff_from(&b).collect();
         assert_eq!(changed.len(), 9);
-        assert!(changed.iter().all(|&(_, v)| *v == 0));
+        assert!(changed.iter().all(|(_, c)| **c.current() == 1));
     }
 
     #[test]
-    fn diff_different_sizes() {
-        let a = GridBuf::new_filled(2, 2, 0u8);
-        let b = GridBuf::new_filled(3, 3, 0u8);
+    fn diff_larger_than_other() {
+        let a = GridBuf::new_filled(3, 3, 0u8);
+        let b = GridBuf::new_filled(2, 2, 0u8);
 
-        // All positions in self (2x2) are considered changed
-        let changed: Vec<_> = a.diff(&b).collect();
-        assert_eq!(changed.len(), 4);
+        // Positions outside `b`'s bounds are reported as `Added`.
+        let changed: Vec<_> = a.diff_from(&b).collect();
+        assert_eq!(changed.len(), 5);
+        assert!(
+            changed
+                .iter()
+                .all(|(_, c)| matches!(c, GridChange::Added(_)))
+        );
     }
 }

--- a/src/ops/diff.rs
+++ b/src/ops/diff.rs
@@ -1,6 +1,6 @@
 use crate::{
     core::{Pos, Rect},
-    ops::{ExactSizeGrid, GridRead, layout::Traversal as _},
+    ops::{ExactSizeGrid, GridRead, layout::Layout as _},
 };
 
 /// Describes how a single cell differs between two grids, as yielded by [`GridDiff::diff_from`].

--- a/src/ops/draw.rs
+++ b/src/ops/draw.rs
@@ -29,7 +29,7 @@ pub fn copy_rect<'a, E>(
     from: Rect,
     to: Pos,
 ) {
-    dst.fill_rect_iter(
+    dst.fill_rect_from_iter(
         Rect::from_ltwh(to.x, to.y, from.width(), from.height()),
         src.iter_rect(from),
     );

--- a/src/ops/read.rs
+++ b/src/ops/read.rs
@@ -27,6 +27,7 @@ pub trait GridRead: GridBase {
     /// Returns a reference to an element at a specified position.
     ///
     /// If the position is out of bounds, it returns `None`.
+    #[must_use]
     fn get(&self, pos: Pos) -> Option<Self::Element<'_>>;
 
     /// Returns an iterator over elements in a rectangular region of the grid.
@@ -67,37 +68,37 @@ pub trait GridRead: GridBase {
         let trimmed = self.trim_rect(bounds);
         Self::Layout::iter_pos(trimmed).filter_map(move |pos| self.get(pos).map(|elem| (pos, elem)))
     }
-}
 
-/// A trait for grids that can be iterated over.
-pub trait GridIter: GridRead {
     /// Returns an iterator over the elements of the grid.
-    fn iter(&self) -> impl Iterator<Item = Self::Element<'_>>;
-
-    /// Returns an iterator over `(position, element)` pairs for the entire grid.
     ///
-    /// This is the grixy equivalent of `rg::Grid::cells()`.
-    fn iter_with_pos(&self) -> impl Iterator<Item = (Pos, Self::Element<'_>)>;
-
-    /// Alias for [`iter_with_pos`](GridIter::iter_with_pos).
-    ///
-    /// Matches the naming convention of `ndarray::indexed_iter()` and
-    /// `image::ImageBuffer::enumerate_pixels()`.
-    fn cells(&self) -> impl Iterator<Item = (Pos, Self::Element<'_>)> {
-        self.iter_with_pos()
-    }
-}
-
-impl<T> GridIter for T
-where
-    T: GridRead + ExactSizeGrid,
-{
-    fn iter(&self) -> impl Iterator<Item = Self::Element<'_>> {
+    /// Requires [`ExactSizeGrid`] to determine the grid's bounds.
+    fn iter(&self) -> impl Iterator<Item = Self::Element<'_>>
+    where
+        Self: ExactSizeGrid,
+    {
         self.iter_rect(Rect::from_ltwh(0, 0, self.width(), self.height()))
     }
 
-    fn iter_with_pos(&self) -> impl Iterator<Item = (Pos, Self::Element<'_>)> {
+    /// Returns an iterator over `(position, element)` pairs for the entire grid.
+    ///
+    /// This is the grixy equivalent of `rg::Grid::cells()`. Requires [`ExactSizeGrid`] to
+    /// determine the grid's bounds.
+    fn iter_with_pos(&self) -> impl Iterator<Item = (Pos, Self::Element<'_>)>
+    where
+        Self: ExactSizeGrid,
+    {
         self.iter_rect_with_pos(Rect::from_ltwh(0, 0, self.width(), self.height()))
+    }
+
+    /// Alias for [`iter_with_pos`](GridRead::iter_with_pos).
+    ///
+    /// Matches the naming convention of `ndarray::indexed_iter()` and
+    /// `image::ImageBuffer::enumerate_pixels()`.
+    fn cells(&self) -> impl Iterator<Item = (Pos, Self::Element<'_>)>
+    where
+        Self: ExactSizeGrid,
+    {
+        self.iter_with_pos()
     }
 }
 

--- a/src/ops/read.rs
+++ b/src/ops/read.rs
@@ -2,7 +2,7 @@ use crate::{
     core::{Pos, Rect},
     ops::{
         ExactSizeGrid, GridBase,
-        layout::{self, Traversal as _},
+        layout::{self, Layout as _},
     },
 };
 
@@ -22,7 +22,7 @@ pub trait GridRead: GridBase {
     /// traversal order defined by this layout.
     ///
     /// [`RowMajor`][layout::RowMajor] is a reasonable default implementation for most grids.
-    type Layout: layout::Traversal;
+    type Layout: layout::Layout;
 
     /// Returns a reference to an element at a specified position.
     ///
@@ -38,12 +38,12 @@ pub trait GridRead: GridBase {
     ///
     /// ## Performance
     ///
-    /// The default implementation uses [`Traversal::iter_pos`] to iterate over the rectangle,
+    /// The default implementation uses [`Layout::iter_pos`] to iterate over the rectangle,
     /// involving bounds checking for each element. Other implementations may optimize this, for
     /// example by using a more efficient iteration strategy (for linear reads, reduced bounds
     /// checking, etc.).
     ///
-    /// [`Traversal::iter_pos`]: layout::Traversal::iter_pos
+    /// [`Layout::iter_pos`]: layout::Layout::iter_pos
     fn iter_rect(&self, bounds: Rect) -> impl Iterator<Item = Self::Element<'_>> {
         Self::Layout::iter_pos(self.trim_rect(bounds)).filter_map(move |pos| self.get(pos))
     }

--- a/src/ops/unchecked/read.rs
+++ b/src/ops/unchecked/read.rs
@@ -2,7 +2,7 @@ use crate::{
     core::{Pos, Rect},
     ops::{
         GridBase, GridRead,
-        layout::{self, Traversal as _},
+        layout::{self, Layout as _},
         unchecked::TrustedSizeGrid,
     },
 };
@@ -15,7 +15,7 @@ pub trait GridReadUnchecked {
         Self: 'a;
 
     /// The layout of the grid, which determines how elements are stored and accessed.
-    type Layout: layout::Traversal;
+    type Layout: layout::Layout;
 
     /// Returns an element, without doing bounds checking.
     ///
@@ -47,7 +47,7 @@ pub trait GridReadUnchecked {
     ///
     /// ## Performance
     ///
-    /// The default implementation uses [`layout::Traversal::iter_pos`] to iterate over the rectangle,
+    /// The default implementation uses [`layout::Layout::iter_pos`] to iterate over the rectangle,
     /// calling [`get_unchecked`](GridReadUnchecked::get_unchecked) for each position.
     ///
     /// [undefined behavior]: https://doc.rust-lang.org/reference/behavior-considered-undefined.html

--- a/src/ops/unchecked/write.rs
+++ b/src/ops/unchecked/write.rs
@@ -2,7 +2,7 @@ use crate::{
     core::{GridError, HasSize, Pos, Rect},
     ops::{
         GridBase, GridWrite,
-        layout::{self, Traversal as _},
+        layout::{self, Layout as _},
         unchecked::TrustedSizeGrid,
     },
 };
@@ -13,7 +13,7 @@ pub trait GridWriteUnchecked {
     type Element;
 
     /// The type of layout used for the grid.
-    type Layout: layout::Traversal;
+    type Layout: layout::Layout;
 
     /// Sets the element at a specified position without bounds checking.
     ///
@@ -45,11 +45,11 @@ pub trait GridWriteUnchecked {
     ///
     /// ## Performance
     ///
-    /// The default implementation uses [`Traversal::iter_pos`] to iterate over the rectangle,
+    /// The default implementation uses [`Layout::iter_pos`] to iterate over the rectangle,
     /// calling [`set_unchecked`](GridWriteUnchecked::set_unchecked) for each position.
     ///
     /// [undefined behavior]: https://doc.rust-lang.org/reference/behavior-considered-undefined.html
-    /// [`Traversal::iter_pos`]: layout::Traversal::iter_pos
+    /// [`Layout::iter_pos`]: layout::Layout::iter_pos
     unsafe fn fill_rect_with_unchecked(
         &mut self,
         dst: Rect,
@@ -80,10 +80,10 @@ pub trait GridWriteUnchecked {
     ///
     /// ## Performance
     ///
-    /// The default implementation zips the iterator with [`Traversal::iter_pos`], calling
+    /// The default implementation zips the iterator with [`Layout::iter_pos`], calling
     /// [`set_unchecked`](GridWriteUnchecked::set_unchecked) for each yielded pair.
     ///
-    /// [`Traversal::iter_pos`]: layout::Traversal::iter_pos
+    /// [`Layout::iter_pos`]: layout::Layout::iter_pos
     unsafe fn fill_rect_from_iter_unchecked(
         &mut self,
         dst: Rect,

--- a/src/ops/unchecked/write.rs
+++ b/src/ops/unchecked/write.rs
@@ -50,7 +50,11 @@ pub trait GridWriteUnchecked {
     ///
     /// [undefined behavior]: https://doc.rust-lang.org/reference/behavior-considered-undefined.html
     /// [`Traversal::iter_pos`]: layout::Traversal::iter_pos
-    unsafe fn fill_rect_unchecked(&mut self, dst: Rect, mut f: impl FnMut(Pos) -> Self::Element) {
+    unsafe fn fill_rect_with_unchecked(
+        &mut self,
+        dst: Rect,
+        mut f: impl FnMut(Pos) -> Self::Element,
+    ) {
         Self::Layout::iter_pos(dst).for_each(|pos| unsafe {
             self.set_unchecked(pos, f(pos));
         });
@@ -66,7 +70,7 @@ pub trait GridWriteUnchecked {
     /// ## Safety
     ///
     /// The caller must ensure that **every position** in `dst` is a valid position in the
-    /// grid (see [`fill_rect_unchecked`](GridWriteUnchecked::fill_rect_unchecked)).
+    /// grid (see [`fill_rect_with_unchecked`](GridWriteUnchecked::fill_rect_with_unchecked)).
     ///
     /// Additionally, if the iterator **yields more elements** than the number of positions in
     /// `dst`, the excess elements are silently dropped. If the iterator is an exact-size iterator
@@ -80,7 +84,7 @@ pub trait GridWriteUnchecked {
     /// [`set_unchecked`](GridWriteUnchecked::set_unchecked) for each yielded pair.
     ///
     /// [`Traversal::iter_pos`]: layout::Traversal::iter_pos
-    unsafe fn fill_rect_iter_unchecked(
+    unsafe fn fill_rect_from_iter_unchecked(
         &mut self,
         dst: Rect,
         iter: impl IntoIterator<Item = Self::Element>,
@@ -100,21 +104,21 @@ pub trait GridWriteUnchecked {
     /// ## Safety
     ///
     /// The caller must ensure that **every position** in `bounds` is a valid position in the
-    /// grid (see [`fill_rect_unchecked`](GridWriteUnchecked::fill_rect_unchecked)).
+    /// grid (see [`fill_rect_with_unchecked`](GridWriteUnchecked::fill_rect_with_unchecked)).
     ///
     /// Writing to memory outside the grid's allocated storage is _[undefined behavior][]_.
     ///
     /// ## Performance
     ///
-    /// The default implementation delegates to [`Self::fill_rect_unchecked`], wrapping the value in a
+    /// The default implementation delegates to [`Self::fill_rect_with_unchecked`], wrapping the value in a
     /// closure. Specialized implementations may use `memset`-style operations for `Copy` types.
     ///
     /// [undefined behavior]: https://doc.rust-lang.org/reference/behavior-considered-undefined.html
-    unsafe fn fill_rect_solid_unchecked(&mut self, bounds: Rect, value: Self::Element)
+    unsafe fn fill_rect_unchecked(&mut self, bounds: Rect, value: Self::Element)
     where
         Self::Element: Copy,
     {
-        unsafe { self.fill_rect_unchecked(bounds, |_| value) };
+        unsafe { self.fill_rect_with_unchecked(bounds, |_| value) };
     }
 }
 
@@ -134,25 +138,25 @@ impl<T: GridBase + GridWriteUnchecked + TrustedSizeGrid> GridWrite for T {
         }
     }
 
-    fn fill_rect(&mut self, bounds: Rect, f: impl FnMut(Pos) -> Self::Element) {
+    fn fill_rect_with(&mut self, bounds: Rect, f: impl FnMut(Pos) -> Self::Element) {
         let size = self.size().to_rect();
         let rect = bounds.intersect(size);
-        unsafe { self.fill_rect_unchecked(rect, f) }
+        unsafe { self.fill_rect_with_unchecked(rect, f) }
     }
 
-    fn fill_rect_iter(&mut self, dst: Rect, iter: impl IntoIterator<Item = Self::Element>) {
+    fn fill_rect_from_iter(&mut self, dst: Rect, iter: impl IntoIterator<Item = Self::Element>) {
         let size = self.size().to_rect();
         let rect = dst.intersect(size);
-        unsafe { self.fill_rect_iter_unchecked(rect, iter) }
+        unsafe { self.fill_rect_from_iter_unchecked(rect, iter) }
     }
 
-    fn fill_rect_solid(&mut self, dst: Rect, value: Self::Element)
+    fn fill_rect(&mut self, dst: Rect, value: Self::Element)
     where
         Self::Element: Copy,
     {
         let size = self.size().to_rect();
         let rect = dst.intersect(size);
-        unsafe { self.fill_rect_solid_unchecked(rect, value) }
+        unsafe { self.fill_rect_unchecked(rect, value) }
     }
 }
 
@@ -238,7 +242,7 @@ mod tests {
     fn impl_unsafe_fill_rect_complete() {
         let mut grid = UncheckedTestGrid { grid: [[0; 3]; 3] };
         let bounds = Rect::from_ltrb(0, 0, 3, 3).unwrap();
-        grid.fill_rect(bounds, |_| 42);
+        grid.fill_rect_with(bounds, |_| 42);
         assert_eq!(grid.grid, [[42; 3]; 3]);
     }
 
@@ -246,7 +250,7 @@ mod tests {
     fn impl_unsafe_fill_rect_partial_in_bounds() {
         let mut grid = UncheckedTestGrid { grid: [[0; 3]; 3] };
         let bounds = Rect::from_ltrb(0, 0, 2, 2).unwrap();
-        grid.fill_rect(bounds, |pos| if pos.x == 1 && pos.y == 1 { 99 } else { 42 });
+        grid.fill_rect_with(bounds, |pos| if pos.x == 1 && pos.y == 1 { 99 } else { 42 });
         assert_eq!(grid.grid, [[42, 42, 0], [42, 99, 0], [0, 0, 0]]);
     }
 
@@ -254,7 +258,7 @@ mod tests {
     fn impl_unsafe_fill_rect_partial_out_of_bounds() {
         let mut grid = UncheckedTestGrid { grid: [[0; 3]; 3] };
         let bounds = Rect::from_ltrb(1, 1, 4, 4).unwrap(); // Out of bounds on the right and bottom
-        grid.fill_rect(bounds, |_| 42);
+        grid.fill_rect_with(bounds, |_| 42);
         assert_eq!(grid.grid, [[0, 0, 0], [0, 42, 42], [0, 42, 42]]);
     }
 
@@ -262,7 +266,7 @@ mod tests {
     fn impl_unsafe_fill_rect_iter_complete() {
         let mut grid = UncheckedTestGrid { grid: [[0; 3]; 3] };
         let bounds = Rect::from_ltrb(0, 0, 3, 3).unwrap();
-        grid.fill_rect_iter(bounds, vec![42; 9]);
+        grid.fill_rect_from_iter(bounds, vec![42; 9]);
         assert_eq!(grid.grid, [[42; 3]; 3]);
     }
 
@@ -270,7 +274,7 @@ mod tests {
     fn impl_unsafe_fill_rect_iter_partial_in_bounds() {
         let mut grid = UncheckedTestGrid { grid: [[0; 3]; 3] };
         let bounds = Rect::from_ltrb(0, 0, 2, 2).unwrap();
-        grid.fill_rect_iter(bounds, vec![42, 99]);
+        grid.fill_rect_from_iter(bounds, vec![42, 99]);
 
         #[rustfmt::skip]
         assert_eq!(grid.grid, [
@@ -284,7 +288,7 @@ mod tests {
     fn impl_unsafe_fill_rect_iter_partial_in_bounds_with_extra() {
         let mut grid = UncheckedTestGrid { grid: [[0; 3]; 3] };
         let bounds = Rect::from_ltrb(0, 0, 2, 1).unwrap();
-        grid.fill_rect_iter(bounds, vec![42, 99, 100]);
+        grid.fill_rect_from_iter(bounds, vec![42, 99, 100]);
 
         #[rustfmt::skip]
         assert_eq!(grid.grid, [
@@ -298,7 +302,7 @@ mod tests {
     fn impl_unsafe_fill_rect_iter_partial_out_of_bounds() {
         let mut grid = UncheckedTestGrid { grid: [[0; 3]; 3] };
         let bounds = Rect::from_ltrb(1, 1, 4, 4).unwrap(); // Out of bounds on the right and bottom
-        grid.fill_rect_iter(bounds, vec![42, 99, 100]);
+        grid.fill_rect_from_iter(bounds, vec![42, 99, 100]);
 
         #[rustfmt::skip]
         assert_eq!(grid.grid, [
@@ -312,7 +316,7 @@ mod tests {
     fn impl_unsafe_fill_rect_iter_out_of_bounds() {
         let mut grid = UncheckedTestGrid { grid: [[0; 3]; 3] };
         let bounds = Rect::from_ltrb(3, 3, 4, 4).unwrap(); // Out of bounds on the right and bottom
-        grid.fill_rect_iter(bounds, vec![42, 99, 100]);
+        grid.fill_rect_from_iter(bounds, vec![42, 99, 100]);
 
         #[rustfmt::skip]
         assert_eq!(grid.grid, [
@@ -323,10 +327,10 @@ mod tests {
     }
 
     #[test]
-    fn impl_unsafe_fill_rect_solid() {
+    fn impl_unsafe_fill_rect() {
         let mut grid = UncheckedTestGrid { grid: [[0; 3]; 3] };
         let bounds = Rect::from_ltrb(0, 0, 3, 3).unwrap();
-        grid.fill_rect_solid(bounds, 42);
+        grid.fill_rect(bounds, 42);
 
         assert_eq!(grid.grid, [[42; 3]; 3]);
     }

--- a/src/ops/write.rs
+++ b/src/ops/write.rs
@@ -4,7 +4,7 @@ use crate::{
     core::{GridError, Pos, Rect},
     ops::{
         ExactSizeGrid, GridBase,
-        layout::{self, Traversal as _},
+        layout::{self, Layout as _},
     },
 };
 
@@ -29,7 +29,7 @@ pub trait GridWrite: GridBase {
     /// traversal order defined by this layout.
     ///
     /// [`RowMajor`][layout::RowMajor] is a reasonable default implementation for most grids.
-    type Layout: layout::Traversal;
+    type Layout: layout::Layout;
 
     /// Sets the element at a specified position.
     ///
@@ -88,12 +88,12 @@ pub trait GridWrite: GridBase {
     ///
     /// ## Performance
     ///
-    /// The default implementation uses [`Traversal::iter_pos`] to iterate over the rectangle,
+    /// The default implementation uses [`Layout::iter_pos`] to iterate over the rectangle,
     /// involving bounds checking for each element. Other implementations may optimize this, for
     /// example by using a more efficient iteration strategy (for linear reads, reduced bounds
     /// checking, etc.).
     ///
-    /// [`Traversal::iter_pos`]: layout::Traversal::iter_pos
+    /// [`Layout::iter_pos`]: layout::Layout::iter_pos
     fn clear_rect(&mut self, bounds: Rect)
     where
         Self::Element: Default,
@@ -126,12 +126,12 @@ pub trait GridWrite: GridBase {
     ///
     /// ## Performance
     ///
-    /// The default implementation uses [`Traversal::iter_pos`] to iterate over the rectangle,
+    /// The default implementation uses [`Layout::iter_pos`] to iterate over the rectangle,
     /// involving bounds checking for each element. Other implementations may optimize this, for
     /// example by using a more efficient iteration strategy (for linear reads, reduced bounds
     /// checking, etc.).
     ///
-    /// [`Traversal::iter_pos`]: layout::Traversal::iter_pos
+    /// [`Layout::iter_pos`]: layout::Layout::iter_pos
     fn fill_rect_with(&mut self, bounds: Rect, mut f: impl FnMut(Pos) -> Self::Element) {
         Self::Layout::iter_pos(self.trim_rect(bounds)).for_each(|pos| {
             let _ = self.set(pos, f(pos));
@@ -149,12 +149,12 @@ pub trait GridWrite: GridBase {
     ///
     /// ## Performance
     ///
-    /// The default implementation uses [`Traversal::iter_pos`] to iterate over the rectangle,
+    /// The default implementation uses [`Layout::iter_pos`] to iterate over the rectangle,
     /// involving bounds checking for each element. Other implementations may optimize this, for
     /// example by using a more efficient iteration strategy (for linear reads, reduced bounds
     /// checking, etc.).
     ///
-    /// [`Traversal::iter_pos`]: layout::Traversal::iter_pos
+    /// [`Layout::iter_pos`]: layout::Layout::iter_pos
     fn fill_rect_from_iter(&mut self, dst: Rect, iter: impl IntoIterator<Item = Self::Element>) {
         Self::Layout::iter_pos(self.trim_rect(dst))
             .zip(iter)

--- a/src/ops/write.rs
+++ b/src/ops/write.rs
@@ -9,6 +9,13 @@ use crate::{
 };
 
 /// Write elements to a 2-dimensional grid position.
+///
+/// # Naming convention
+///
+/// Method names follow `std::slice`'s `fill`/`fill_with` convention: [`fill`](GridWrite::fill)
+/// and [`fill_rect`](GridWrite::fill_rect) take a single `Copy` value, while the `_with` suffix
+/// (e.g. [`fill_with`](GridWrite::fill_with)) takes a position-driven closure, and
+/// `_from_iter` (e.g. [`fill_from_iter`](GridWrite::fill_from_iter)) consumes an iterator.
 pub trait GridWrite: GridBase {
     /// The type of elements in the grid.
     type Element;
@@ -42,35 +49,35 @@ pub trait GridWrite: GridBase {
         self.clear_rect(self.size().to_rect());
     }
 
-    /// Sets elements within the grid.
+    /// Sets every element in the grid to `value`.
     ///
     /// Elements are set in an order agreeable to the grid's internal layout.
-    fn fill(&mut self, f: impl FnMut(Pos) -> Self::Element)
+    fn fill(&mut self, value: Self::Element)
+    where
+        Self::Element: Copy,
+        Self: ExactSizeGrid,
+    {
+        self.fill_rect(self.size().to_rect(), value);
+    }
+
+    /// Sets every element in the grid using a position-driven closure.
+    ///
+    /// Elements are set in an order agreeable to the grid's internal layout.
+    fn fill_with(&mut self, f: impl FnMut(Pos) -> Self::Element)
     where
         Self: ExactSizeGrid,
     {
-        self.fill_rect(self.size().to_rect(), f);
+        self.fill_rect_with(self.size().to_rect(), f);
     }
 
     /// Sets elements within the grid from an iterator.
     ///
     /// Elements are set in an order agreeable to the grid's internal layout.
-    fn fill_iter(&mut self, iter: impl Iterator<Item = Self::Element>)
+    fn fill_from_iter(&mut self, iter: impl Iterator<Item = Self::Element>)
     where
         Self: ExactSizeGrid,
     {
-        self.fill_rect_iter(self.size().to_rect(), iter);
-    }
-
-    /// Sets elements within the grid to a single value.
-    ///
-    /// Elements are set in an order agreeable to the grid's internal layout.
-    fn fill_solid(&mut self, value: Self::Element)
-    where
-        Self::Element: Copy,
-        Self: ExactSizeGrid,
-    {
-        self.fill_rect_solid(self.size().to_rect(), value);
+        self.fill_rect_from_iter(self.size().to_rect(), iter);
     }
 
     /// Clears a rectangular region of the grid, setting all elements to their default value.
@@ -91,10 +98,27 @@ pub trait GridWrite: GridBase {
     where
         Self::Element: Default,
     {
-        self.fill_rect(bounds, |_| Default::default());
+        self.fill_rect_with(bounds, |_| Default::default());
     }
 
-    /// Sets elements within a rectangular region of the grid.
+    /// Sets every element within a rectangular region of the grid to `value`.
+    ///
+    /// Elements are set in an order agreeable to the grid's internal layout. Out-of-bounds
+    /// elements are skipped, and the bounding rectangle is treated as _exclusive_ of the right and
+    /// bottom edges.
+    ///
+    /// ## Performance
+    ///
+    /// The default implementation delegates to [`Self::fill_rect_with`], wrapping the value in a
+    /// closure. Specialized implementations may use `memset`-style operations for `Copy` types.
+    fn fill_rect(&mut self, dst: Rect, value: Self::Element)
+    where
+        Self::Element: Copy,
+    {
+        self.fill_rect_with(dst, |_| value);
+    }
+
+    /// Sets elements within a rectangular region of the grid using a position-driven closure.
     ///
     /// Elements are set in an order agreeable to the grid's internal layout. Out-of-bounds
     /// elements are skipped, and the bounding rectangle is treated as _exclusive_ of the right and
@@ -108,13 +132,13 @@ pub trait GridWrite: GridBase {
     /// checking, etc.).
     ///
     /// [`Traversal::iter_pos`]: layout::Traversal::iter_pos
-    fn fill_rect(&mut self, bounds: Rect, mut f: impl FnMut(Pos) -> Self::Element) {
+    fn fill_rect_with(&mut self, bounds: Rect, mut f: impl FnMut(Pos) -> Self::Element) {
         Self::Layout::iter_pos(self.trim_rect(bounds)).for_each(|pos| {
             let _ = self.set(pos, f(pos));
         });
     }
 
-    /// Sets elements within a rectangular region of the grid.
+    /// Sets elements within a rectangular region of the grid from an iterator.
     ///
     /// Elements are set in an order agreeable to the grid's internal layout. Out-of-bounds
     /// elements are skipped, and the bounding rectangle is treated as _exclusive_ of the right and
@@ -131,33 +155,12 @@ pub trait GridWrite: GridBase {
     /// checking, etc.).
     ///
     /// [`Traversal::iter_pos`]: layout::Traversal::iter_pos
-    fn fill_rect_iter(&mut self, dst: Rect, iter: impl IntoIterator<Item = Self::Element>) {
+    fn fill_rect_from_iter(&mut self, dst: Rect, iter: impl IntoIterator<Item = Self::Element>) {
         Self::Layout::iter_pos(self.trim_rect(dst))
             .zip(iter)
             .for_each(|(pos, value)| {
                 let _ = self.set(pos, value);
             });
-    }
-
-    /// Sets elements within a rectangular region of the grid.
-    ///
-    /// Elements are set in an order agreeable to the grid's internal layout. Out-of-bounds
-    /// elements are skipped, and the bounding rectangle is treated as _exclusive_ of the right and
-    /// bottom edges.
-    ///
-    /// ## Performance
-    ///
-    /// The default implementation uses [`Traversal::iter_pos`] to iterate over the rectangle,
-    /// involving bounds checking for each element. Other implementations may optimize this, for
-    /// example by using a more efficient iteration strategy (for linear reads, reduced bounds
-    /// checking, etc.).
-    ///
-    /// [`Traversal::iter_pos`]: layout::Traversal::iter_pos
-    fn fill_rect_solid(&mut self, dst: Rect, value: Self::Element)
-    where
-        Self::Element: Copy,
-    {
-        self.fill_rect(self.trim_rect(dst), |_| value);
     }
 }
 
@@ -221,26 +224,26 @@ mod tests {
     }
 
     #[test]
+    fn impl_checked_fill_rect_with() {
+        let mut grid = TestGrid { grid: [[0; 3]; 3] };
+        let bounds = Rect::from_ltrb(0, 0, 3, 3).unwrap();
+        grid.fill_rect_with(bounds, |_| 42);
+        assert_eq!(grid.grid, [[42; 3]; 3]);
+    }
+
+    #[test]
+    fn impl_checked_fill_rect_from_iter() {
+        let mut grid = TestGrid { grid: [[0; 3]; 3] };
+        let bounds = Rect::from_ltrb(0, 0, 3, 3).unwrap();
+        grid.fill_rect_from_iter(bounds, vec![42; 9]);
+        assert_eq!(grid.grid, [[42; 3]; 3]);
+    }
+
+    #[test]
     fn impl_checked_fill_rect() {
         let mut grid = TestGrid { grid: [[0; 3]; 3] };
         let bounds = Rect::from_ltrb(0, 0, 3, 3).unwrap();
-        grid.fill_rect(bounds, |_| 42);
-        assert_eq!(grid.grid, [[42; 3]; 3]);
-    }
-
-    #[test]
-    fn impl_checked_fill_rect_iter() {
-        let mut grid = TestGrid { grid: [[0; 3]; 3] };
-        let bounds = Rect::from_ltrb(0, 0, 3, 3).unwrap();
-        grid.fill_rect_iter(bounds, vec![42; 9]);
-        assert_eq!(grid.grid, [[42; 3]; 3]);
-    }
-
-    #[test]
-    fn impl_checked_fill_rect_solid() {
-        let mut grid = TestGrid { grid: [[0; 3]; 3] };
-        let bounds = Rect::from_ltrb(0, 0, 3, 3).unwrap();
-        grid.fill_rect_solid(bounds, 42);
+        grid.fill_rect(bounds, 42);
         assert_eq!(grid.grid, [[42; 3]; 3]);
     }
 }

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -13,7 +13,7 @@
 pub use crate::buf::{GridBuf, bits::GridBits};
 pub use crate::core::{GridError, HasSize as _, Pos, Rect, Size};
 pub use crate::ops::{
-    ExactSizeGrid as _, GridBase, GridDiff as _, GridIter as _, GridRead, GridWrite, copy_rect,
+    ExactSizeGrid as _, GridBase, GridChange, GridDiff as _, GridRead, GridWrite, copy_rect,
     layout::{Block, ColumnMajor, Linear as _, RowMajor, Traversal as _},
 };
 pub use crate::transform::GridConvertExt as _;

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -14,6 +14,6 @@ pub use crate::buf::{GridBuf, bits::GridBits};
 pub use crate::core::{GridError, HasSize as _, Pos, Rect, Size};
 pub use crate::ops::{
     ExactSizeGrid as _, GridBase, GridChange, GridDiff as _, GridRead, GridWrite, copy_rect,
-    layout::{Block, ColumnMajor, Linear as _, RowMajor, Traversal as _},
+    layout::{Block, ColumnMajor, Layout as _, LinearLayout as _, RowMajor},
 };
 pub use crate::transform::GridConvertExt as _;

--- a/src/test.rs
+++ b/src/test.rs
@@ -10,7 +10,7 @@ use crate::{
     core::{GridError, Size},
     ops::{
         GridBase, GridRead, GridWrite,
-        layout::{self, Traversal as _},
+        layout::{self, Layout as _},
     },
 };
 

--- a/src/transform.rs
+++ b/src/transform.rs
@@ -54,6 +54,18 @@
 //! // Original grid is still accessible
 //! assert_eq!(rc.get(Pos::new(1, 1)), Some(&1));
 //! ```
+//!
+//! ## A note on monomorphization
+//!
+//! Each transform (`Copied<T, G>`, `Mapped<F, G, T>`, `Viewed<G>`, `Scaled<G>`, `Blended<G, F>`)
+//! is its own distinct generic type, and chaining them nests one inside another
+//! (`Scaled<Viewed<Mapped<F, Copied<T, G>, U>>>`, etc). This is the usual zero-cost-abstraction
+//! trade-off: no vtables or dynamic dispatch at runtime, but every distinct chain shape is a
+//! separate monomorphized instantiation at compile time. For a handful of transforms used in a
+//! few call sites this is inconsequential; if a very long or widely-instantiated chain becomes a
+//! compile-time or code-size concern, use [`flatten`](GridConvertExt::flatten) to collapse the
+//! chain into a concrete [`GridBuf`](crate::buf::GridBuf) at the point where you no longer need
+//! further lazy composition.
 
 use core::marker::PhantomData;
 

--- a/src/transform.rs
+++ b/src/transform.rs
@@ -217,7 +217,7 @@ pub trait GridConvertExt: GridRead {
     fn flatten<'a, B, L>(&'a self) -> crate::buf::GridBuf<Self::Element<'a>, B, L>
     where
         B: FromIterator<Self::Element<'a>> + AsRef<[Self::Element<'a>]>,
-        L: layout::Linear,
+        L: layout::LinearLayout,
         Self: Sized,
         Self: ExactSizeGrid,
         Self::Element<'a>: Copy,

--- a/src/transform/blended.rs
+++ b/src/transform/blended.rs
@@ -1,3 +1,5 @@
+use core::ops::Index;
+
 use crate::{
     core::{GridError, Pos, Rect, Size},
     ops::{ExactSizeGrid, GridBase, GridRead, GridWrite},
@@ -67,5 +69,21 @@ where
 
     fn iter_rect(&self, bounds: Rect) -> impl Iterator<Item = Self::Element<'_>> {
         self.source.iter_rect(bounds)
+    }
+}
+
+/// Indexes into the underlying grid by position, forwarding to the source grid's read side.
+///
+/// # Panics
+///
+/// Panics if `pos` is out of bounds. Use [`GridRead::get`] for a non-panicking alternative.
+impl<G, F, T> Index<Pos> for Blended<'_, G, F>
+where
+    G: for<'a> GridRead<Element<'a> = &'a T> + 'static,
+{
+    type Output = T;
+
+    fn index(&self, pos: Pos) -> &T {
+        self.get(pos).expect("position out of bounds")
     }
 }

--- a/src/transform/scaled.rs
+++ b/src/transform/scaled.rs
@@ -1,3 +1,5 @@
+use core::ops::Index;
+
 use crate::{
     core::{Pos, Size},
     ops::{ExactSizeGrid, GridBase, GridRead},
@@ -50,5 +52,22 @@ where
 
     fn get(&self, pos: Pos) -> Option<Self::Element<'_>> {
         self.source.get(pos / self.scale)
+    }
+}
+
+/// Indexes into the scaled grid by position, forwarding to the source grid.
+///
+/// # Panics
+///
+/// Panics if `pos` is out of bounds of the scaled grid. Use [`GridRead::get`] for a
+/// non-panicking alternative.
+impl<G, T> Index<Pos> for Scaled<G>
+where
+    G: for<'a> GridRead<Element<'a> = &'a T> + 'static,
+{
+    type Output = T;
+
+    fn index(&self, pos: Pos) -> &T {
+        self.get(pos).expect("position out of bounds")
     }
 }

--- a/src/transform/viewed.rs
+++ b/src/transform/viewed.rs
@@ -1,3 +1,5 @@
+use core::ops::Index;
+
 use crate::{
     core::{Pos, Rect, Size},
     ops::{ExactSizeGrid, GridBase, GridRead},
@@ -58,5 +60,22 @@ where
     fn iter_rect(&self, bounds: Rect) -> impl Iterator<Item = Self::Element<'_>> {
         let bounds = bounds - self.bounds.top_left();
         self.source.iter_rect(bounds)
+    }
+}
+
+/// Indexes into the view by position, forwarding to the source grid.
+///
+/// # Panics
+///
+/// Panics if `pos` is out of bounds of the view. Use [`GridRead::get`] for a non-panicking
+/// alternative.
+impl<G, T> Index<Pos> for Viewed<G>
+where
+    G: for<'a> GridRead<Element<'a> = &'a T> + 'static,
+{
+    type Output = T;
+
+    fn index(&self, pos: Pos) -> &T {
+        self.get(pos).expect("position out of bounds")
     }
 }


### PR DESCRIPTION
## Summary

Two stacked commits:

1. **`refactor: pre-1.0 API/architecture pass`** — implements the design review recommendations from an internal audit. All breaking, no back-compat shims (pre-1.0 alpha).
   - Fold `GridIter` into `GridRead` as default methods (`iter`, `iter_with_pos`, `cells`), gated on `Self: ExactSizeGrid`. `GridIter` trait removed.
   - `GridDiff::diff()` renamed to `diff_from()`; returns `(Pos, GridChange<Element>)` instead of `(Pos, Element)`. Cells beyond `other`'s bounds are now reported as `GridChange::Added` instead of unconditionally treating size-mismatched grids as fully changed.
   - `GridWrite` renamed to follow `std::slice`'s `fill`/`fill_with` convention: `fill_solid` -> `fill`, `fill` -> `fill_with`, `fill_iter` -> `fill_from_iter`, and the `_rect`/`_unchecked` variants to match.
   - Added `Index<Pos>` impls for `Viewed`, `Scaled`, `Blended` (where the source's `Element<'a> = &'a T`). A fully generic blanket `Index<Pos>` over any `GridRead<Element=&T>` was attempted but rejected by Rust's coherence rules (E0210) - documented in code.
   - Added `VecGrid`/`VecGridColMajor` (alloc) and `SliceGrid`/`SliceGridMut` type aliases in `grixy::buf`.
   - `GridRead::get()` is now `#[must_use]`. Documented `GridError`'s `#[non_exhaustive]` rationale, `GridBase::size_hint()` implementation guidance, added a safety/unchecked-operations guide to crate root docs, documented the transform monomorphization tradeoff.
   - Investigated `Box<T>: GridRead` - not implementable due to `Box`'s `#[fundamental]` attribute conflicting with the existing unchecked-read blanket impl; documented instead of forced.
   - Updated README feature matrix and AGENTS.md architecture notes.

2. **`chore: bump ixy to 0.6.0-alpha.9`** - mechanical rename to follow ixy's own breaking rename:
   - `layout::Traversal` -> `layout::Layout`
   - `layout::Linear` -> `layout::LinearLayout`
   - `LinearLayout::pos_to_index()`/`index_to_pos()` second param renamed `width` -> `stride` (semantics unchanged); updated in the custom Z-order layout example
   - No behavior change; `core::Size`/`core::Rect`/`HasSize` stay source-compatible since ixy's new generic `Int` parameters default to `usize`
   - Bumped grixy to `0.6.0-alpha.8`, `ixy` requirement to `0.6.0-alpha.9`

## Verification

- `cargo test --all-features` - 133 passed (104 unit + 29 doc)
- `cargo clippy --all-features --all-targets` - pedantic, clean
- `cargo doc --all-features -D warnings` - clean
- `cargo fmt --all -- --check` - clean
- Each feature combination builds: `--no-default-features`, `buffer`, `buffer,alloc`, `serde`, `cell`, `--all-features`

Please review before merging - not merging this myself per request.
