### PR TITLE
chore: bump ixy to 0.6.0-alpha.9

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -46,7 +46,7 @@ src/
 │   ├── write.rs    # GridWrite trait (set, fill_*, clear_*)
 │   ├── diff.rs     # GridDiff trait (grid comparison via diff())
 │   ├── draw.rs     # copy_rect() standalone function
-│   ├── layout.rs   # Re-exports from ixy (RowMajor, ColumnMajor, Block, Linear, Traversal)
+│   ├── layout.rs   # Re-exports from ixy (RowMajor, ColumnMajor, Block, LinearLayout, Layout)
 │   ├── cell.rs     # GridWrite for Cell/RefCell/UnsafeCell wrappers
 │   ├── alloc.rs    # GridRead for Rc/Arc
 │   └── unchecked/  # GridReadUnchecked, GridWriteUnchecked, TrustedSizeGrid

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,32 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.6.0-alpha.8] - 2026-07-03
+
+### Dependencies
+
+- Bumped `ixy` from `0.6.0-alpha.5` to `0.6.0-alpha.9`. Mechanical rename to follow ixy's own
+  breaking rename in that range:
+  - `layout::Traversal` → `layout::Layout`
+  - `layout::Linear` → `layout::LinearLayout`
+  - `LinearLayout::pos_to_index()`/`index_to_pos()`'s second parameter is now named `stride`
+    (was `width`); semantics unchanged
+  - No grixy-visible behavior change; `core::Size`/`core::Rect`/`HasSize` stay source-compatible
+    since ixy's new generic `Int` parameters default to `usize`, matching grixy's existing usage
+- `ixy` is now pinned with an exact requirement (`=0.6.0-alpha.9`) instead of a caret requirement.
+  Previously published `grixy` versions used a loose `ixy = "0.6.0-alpha.5"` requirement, which,
+  because both are pre-1.0 versions on the same `0.6.0` track, let Cargo silently resolve to any
+  newer `0.6.0-alpha.N` release of `ixy` - including ones with breaking renames. Exact-pinning
+  avoids repeating this for future `ixy` prereleases.
+
+### Fixed
+
+- `just semver-checks` no longer hardcodes an old baseline version (previously
+  `0.6.0-alpha.4`). That baseline's own loose `ixy` requirement made it re-resolve to newer,
+  incompatible `ixy` prereleases and fail to build entirely, unrelated to any actual API change.
+  The recipe now lets `cargo-semver-checks` auto-select the baseline (the latest true stable
+  release), which isn't affected by `ixy`'s alpha-track churn.
+
 ## [0.6.0-alpha.6] - 2026-06-19
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -320,7 +320,7 @@ dependencies = [
 
 [[package]]
 name = "grixy"
-version = "0.6.0-alpha.7"
+version = "0.6.0-alpha.8"
 dependencies = [
  "bytemuck",
  "criterion",
@@ -409,9 +409,9 @@ checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
 
 [[package]]
 name = "ixy"
-version = "0.6.0-alpha.5"
+version = "0.6.0-alpha.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38c7555014e6b3d1416a5541b1a38f195b261eeded4e391cafb18484c8a293f4"
+checksum = "cf5db685a29892d524bda3513508e53a4949e452ad4112e9ee5bb13794337b59"
 dependencies = [
  "serde",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ rust-version = "1.87"
 documentation = "https://docs.rs/grixy"
 keywords = ["2d", "grid", "embedded", "no-std", "gamedev"]
 categories = ["game-development", "mathematics", "embedded", "no-std"]
-version = "0.6.0-alpha.7"
+version = "0.6.0-alpha.8"
 
 [lints.rust]
 missing_docs = "warn"
@@ -40,7 +40,7 @@ serde = ["dep:serde", "ixy/serde"]
 all-features = true
 
 [dependencies]
-ixy = { version = "0.6.0-alpha.5" }
+ixy = { version = "=0.6.0-alpha.9" }
 serde = { version = "1.0", optional = true, features = ["derive"] }
 
 [dev-dependencies]

--- a/Justfile
+++ b/Justfile
@@ -42,7 +42,13 @@ doc-check:
     RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --all-features
 
 semver-checks:
-    cargo tool cargo-semver-checks --baseline-version 0.6.0-alpha.4
+    # No --baseline-version pin: previously published 0.6.0-alpha.* releases all depend on a
+    # loose (non-exact) ixy requirement, so cargo-semver-checks re-resolves their `ixy` dependency
+    # against whatever is newest on crates.io when building the baseline - which breaks the
+    # instant ixy publishes another breaking prerelease in the same 0.6.0 track (as happened
+    # going from ixy 0.6.0-alpha.5 to 0.6.0-alpha.9). Letting cargo-semver-checks auto-select the
+    # baseline compares against the latest actual stable release instead, which isn't affected.
+    cargo tool cargo-semver-checks
 
 msrv:
     cargo tool cargo-hack check --rust-version --workspace --all-targets --all-features --ignore-private

--- a/examples/z-order-layout.rs
+++ b/examples/z-order-layout.rs
@@ -3,7 +3,7 @@
 #![allow(missing_docs)]
 
 use grixy::{
-    ops::layout::{Linear, Traversal},
+    ops::layout::{Layout, LinearLayout},
     prelude::*,
 };
 
@@ -30,7 +30,7 @@ const fn unspread_bits(n: u32) -> u32 {
     x
 }
 
-impl Traversal for ZOrderCurve {
+impl Layout for ZOrderCurve {
     fn iter_pos<T: ixy::int::Int>(rect: ixy::Rect<T>) -> impl Iterator<Item = ixy::Pos<T>> {
         RowMajor::iter_pos(rect)
     }
@@ -43,8 +43,8 @@ impl Traversal for ZOrderCurve {
     }
 }
 
-impl Linear for ZOrderCurve {
-    fn pos_to_index(pos: Pos, _width: usize) -> usize {
+impl LinearLayout for ZOrderCurve {
+    fn pos_to_index(pos: Pos, _stride: usize) -> usize {
         let x: u16 = pos.x.try_into().expect("Coordinates must fit in a u16");
         let y: u16 = pos.y.try_into().expect("Coordinates must fit in a u16");
         let x: u32 = x.into();
@@ -56,7 +56,7 @@ impl Linear for ZOrderCurve {
         index as usize
     }
 
-    fn index_to_pos(index: usize, _width: usize) -> Pos {
+    fn index_to_pos(index: usize, _stride: usize) -> Pos {
         let index: u32 = index.try_into().expect("Index must fit in a u32");
         let x = unspread_bits(index);
         let y = unspread_bits(index >> 1);

--- a/src/buf.rs
+++ b/src/buf.rs
@@ -40,9 +40,9 @@ mod impl_slice;
 /// ## Layout
 ///
 /// The grid is stored in a linear buffer, with elements accessed in an order defined by
-/// [`Traversal`].
+/// [`Layout`].
 ///
-/// [`Traversal`]: layout::Traversal
+/// [`Layout`]: layout::Layout
 #[derive(Debug, Clone)]
 pub struct GridBuf<T, B, L> {
     buffer: B,
@@ -54,7 +54,7 @@ pub struct GridBuf<T, B, L> {
 
 impl<T, B, L> GridBuf<T, B, L>
 where
-    L: layout::Linear,
+    L: layout::LinearLayout,
 {
     /// Consumes the `GridBuf`, returning the underlying buffer, width, and height.
     #[must_use]
@@ -67,7 +67,7 @@ where
     pub fn get_mut(&mut self, pos: Pos) -> Option<&mut T>
     where
         B: AsMut<[T]>,
-        L: layout::Linear,
+        L: layout::LinearLayout,
     {
         if self.contains(pos) {
             let idx = L::pos_to_index(pos, self.width);
@@ -80,7 +80,7 @@ where
 
 impl<T, B, L> Index<Pos> for GridBuf<T, B, L>
 where
-    L: layout::Linear,
+    L: layout::LinearLayout,
     B: AsRef<[T]>,
 {
     type Output = T;
@@ -92,7 +92,7 @@ where
 
 impl<T, B, L> IndexMut<Pos> for GridBuf<T, B, L>
 where
-    L: layout::Linear,
+    L: layout::LinearLayout,
     B: AsRef<[T]> + AsMut<[T]>,
 {
     fn index_mut(&mut self, index: Pos) -> &mut Self::Output {
@@ -104,7 +104,7 @@ impl<T, B, L> fmt::Display for GridBuf<T, B, L>
 where
     T: fmt::Display + Default + PartialEq,
     B: AsRef<[T]>,
-    L: layout::Linear,
+    L: layout::LinearLayout,
 {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         for row in 0..self.height {

--- a/src/buf/bits.rs
+++ b/src/buf/bits.rs
@@ -35,14 +35,14 @@ extern crate alloc;
 /// ## Layout
 ///
 /// The grid is stored in a linear buffer, with elements accessed in an order defined by
-/// [`Traversal`].
+/// [`Layout`].
 ///
-/// [`Traversal`]: layout::Traversal
+/// [`Layout`]: layout::Layout
 #[derive(Debug, Clone)]
 pub struct GridBits<T, B, L>
 where
     T: BitOps,
-    L: layout::Linear,
+    L: layout::LinearLayout,
 {
     buffer: B,
     width: usize,
@@ -55,7 +55,7 @@ impl<T, B, L> GridBits<T, B, L>
 where
     T: BitOps,
     B: AsRef<[T]>,
-    L: layout::Linear,
+    L: layout::LinearLayout,
 {
     /// Returns a grid from an existing buffer with a given width in columns.
     ///
@@ -129,7 +129,7 @@ where
 impl<T, L> GridBits<T, alloc::vec::Vec<T>, L>
 where
     T: BitOps,
-    L: layout::Linear,
+    L: layout::LinearLayout,
 {
     /// Creates a new grid with the specified width, height, and layout, filled with the default value.
     ///
@@ -154,7 +154,7 @@ impl<T, B, L> AsRef<[T]> for GridBits<T, B, L>
 where
     T: BitOps,
     B: AsRef<[T]>,
-    L: layout::Linear,
+    L: layout::LinearLayout,
 {
     fn as_ref(&self) -> &[T] {
         self.buffer.as_ref()
@@ -165,7 +165,7 @@ impl<T, B, L> AsMut<[T]> for GridBits<T, B, L>
 where
     T: BitOps,
     B: AsMut<[T]>,
-    L: layout::Linear,
+    L: layout::LinearLayout,
 {
     fn as_mut(&mut self) -> &mut [T] {
         self.buffer.as_mut()
@@ -176,7 +176,7 @@ impl<T, B, L> GridBits<T, B, L>
 where
     T: BitOps,
     B: AsRef<[T]>,
-    L: layout::Linear,
+    L: layout::LinearLayout,
 {
     /// Consumes the `GridBits`, returning the underlying buffer, width, and height.
     #[must_use]
@@ -198,7 +198,7 @@ impl<T, B, L> GridReadUnchecked for GridBits<T, B, L>
 where
     T: BitOps,
     B: AsRef<[T]>,
-    L: layout::Linear,
+    L: layout::LinearLayout,
 {
     type Element<'a>
         = bool
@@ -237,7 +237,7 @@ impl<T, B, L> GridWriteUnchecked for GridBits<T, B, L>
 where
     T: BitOps,
     B: AsMut<[T]>,
-    L: layout::Linear,
+    L: layout::LinearLayout,
 {
     type Element = bool;
     type Layout = L;
@@ -258,7 +258,7 @@ impl<T, B, L> GridBase for GridBits<T, B, L>
 where
     T: BitOps,
     B: AsRef<[T]>,
-    L: layout::Linear,
+    L: layout::LinearLayout,
 {
     fn size_hint(&self) -> (crate::prelude::Size, Option<crate::prelude::Size>) {
         let size = Size::new(self.width, self.height);
@@ -270,7 +270,7 @@ impl<T, B, L> ExactSizeGrid for GridBits<T, B, L>
 where
     T: BitOps,
     B: AsRef<[T]>,
-    L: layout::Linear,
+    L: layout::LinearLayout,
 {
     fn width(&self) -> usize {
         self.width
@@ -285,7 +285,7 @@ unsafe impl<T, B, L> TrustedSizeGrid for GridBits<T, B, L>
 where
     T: BitOps,
     B: AsRef<[T]>,
-    L: layout::Linear,
+    L: layout::LinearLayout,
 {
 }
 
@@ -293,7 +293,7 @@ impl<T, B, L> Index<Pos> for GridBits<T, B, L>
 where
     T: BitOps,
     B: AsRef<[T]>,
-    L: layout::Linear,
+    L: layout::LinearLayout,
 {
     type Output = bool;
 

--- a/src/buf/impl_grid.rs
+++ b/src/buf/impl_grid.rs
@@ -10,7 +10,7 @@ use crate::{
 
 impl<T, B, L> GridBase for GridBuf<T, B, L>
 where
-    L: layout::Linear,
+    L: layout::LinearLayout,
 {
     fn size_hint(&self) -> (crate::prelude::Size, Option<crate::prelude::Size>) {
         let size = Size::new(self.width, self.height);
@@ -20,7 +20,7 @@ where
 
 impl<T, B, L> ExactSizeGrid for GridBuf<T, B, L>
 where
-    L: layout::Linear,
+    L: layout::LinearLayout,
 {
     fn width(&self) -> usize {
         self.width
@@ -35,12 +35,12 @@ where
 // and those dimensions match `ExactSizeGrid::width()`/`height()`. The buffer length is always
 // `width * height` (enforced by `from_buffer` and constructors), so unchecked indexing into
 // the buffer at `L::pos_to_index(pos, width)` for any pos within `(0..width, 0..height)` is safe.
-unsafe impl<T, B, L> TrustedSizeGrid for GridBuf<T, B, L> where L: layout::Linear {}
+unsafe impl<T, B, L> TrustedSizeGrid for GridBuf<T, B, L> where L: layout::LinearLayout {}
 
 impl<T, B, L> GridReadUnchecked for GridBuf<T, B, L>
 where
     B: AsRef<[T]>,
-    L: layout::Linear,
+    L: layout::LinearLayout,
 {
     type Element<'a>
         = &'a T
@@ -82,7 +82,7 @@ where
 impl<T, B, L> GridWriteUnchecked for GridBuf<T, B, L>
 where
     B: AsMut<[T]>,
-    L: layout::Linear,
+    L: layout::LinearLayout,
 {
     type Element = T;
     type Layout = L;

--- a/src/buf/impl_new.rs
+++ b/src/buf/impl_new.rs
@@ -7,7 +7,7 @@ use core::marker::PhantomData;
 impl<T, B, L> GridBuf<T, B, L>
 where
     B: AsRef<[T]>,
-    L: layout::Linear,
+    L: layout::LinearLayout,
 {
     /// Returns a grid from an existing buffer with a given width in columns.
     ///
@@ -111,7 +111,7 @@ impl<T> GridBuf<T, alloc::vec::Vec<T>, layout::RowMajor> {
 #[cfg(feature = "alloc")]
 impl<T, L> GridBuf<T, alloc::vec::Vec<T>, L>
 where
-    L: layout::Linear,
+    L: layout::LinearLayout,
 {
     /// Creates a new grid with the specified width and height, filled with a default value.
     ///
@@ -122,7 +122,7 @@ where
     pub fn new_filled_with_layout(width: usize, height: usize, value: T) -> Self
     where
         T: Copy,
-        L: layout::Linear,
+        L: layout::LinearLayout,
     {
         let buffer = alloc::vec![value; width * height];
         Self {

--- a/src/buf/impl_resize.rs
+++ b/src/buf/impl_resize.rs
@@ -7,7 +7,7 @@ use crate::{buf::GridBuf, core::Pos, ops::layout};
 impl<T, L> GridBuf<T, alloc::vec::Vec<T>, L>
 where
     T: Clone + Default,
-    L: layout::Linear,
+    L: layout::LinearLayout,
 {
     /// Resizes the grid to the new dimensions.
     ///

--- a/src/buf/impl_serde.rs
+++ b/src/buf/impl_serde.rs
@@ -18,7 +18,7 @@ impl<T, B, L> Serialize for GridBuf<T, B, L>
 where
     T: Serialize,
     B: AsRef<[T]>,
-    L: layout::Linear,
+    L: layout::LinearLayout,
 {
     fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         use serde::ser::SerializeStruct;
@@ -34,7 +34,7 @@ where
 impl<'de, T, L> Deserialize<'de> for GridBuf<T, alloc::vec::Vec<T>, L>
 where
     T: Deserialize<'de> + Default + Copy,
-    L: layout::Linear,
+    L: layout::LinearLayout,
 {
     fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
         enum Field {
@@ -75,7 +75,7 @@ where
         impl<'de, T, L> Visitor<'de> for GridBufVisitor<T, L>
         where
             T: Deserialize<'de> + Default + Copy,
-            L: layout::Linear,
+            L: layout::LinearLayout,
         {
             type Value = GridBuf<T, alloc::vec::Vec<T>, L>;
 

--- a/src/buf/impl_slice.rs
+++ b/src/buf/impl_slice.rs
@@ -3,7 +3,7 @@ use crate::{buf::GridBuf, ops::layout};
 impl<T, B, L> AsRef<[T]> for GridBuf<T, B, L>
 where
     B: AsRef<[T]>,
-    L: layout::Linear,
+    L: layout::LinearLayout,
 {
     fn as_ref(&self) -> &[T] {
         self.buffer.as_ref()
@@ -13,7 +13,7 @@ where
 impl<T, B, L> AsMut<[T]> for GridBuf<T, B, L>
 where
     B: AsMut<[T]>,
-    L: layout::Linear,
+    L: layout::LinearLayout,
 {
     fn as_mut(&mut self) -> &mut [T] {
         self.buffer.as_mut()

--- a/src/ops/diff.rs
+++ b/src/ops/diff.rs
@@ -1,6 +1,6 @@
 use crate::{
     core::{Pos, Rect},
-    ops::{ExactSizeGrid, GridRead, layout::Traversal as _},
+    ops::{ExactSizeGrid, GridRead, layout::Layout as _},
 };
 
 /// Extension trait for comparing two grids.

--- a/src/ops/read.rs
+++ b/src/ops/read.rs
@@ -2,7 +2,7 @@ use crate::{
     core::{Pos, Rect},
     ops::{
         ExactSizeGrid, GridBase,
-        layout::{self, Traversal as _},
+        layout::{self, Layout as _},
     },
 };
 
@@ -22,7 +22,7 @@ pub trait GridRead: GridBase {
     /// traversal order defined by this layout.
     ///
     /// [`RowMajor`][layout::RowMajor] is a reasonable default implementation for most grids.
-    type Layout: layout::Traversal;
+    type Layout: layout::Layout;
 
     /// Returns a reference to an element at a specified position.
     ///
@@ -37,12 +37,12 @@ pub trait GridRead: GridBase {
     ///
     /// ## Performance
     ///
-    /// The default implementation uses [`Traversal::iter_pos`] to iterate over the rectangle,
+    /// The default implementation uses [`Layout::iter_pos`] to iterate over the rectangle,
     /// involving bounds checking for each element. Other implementations may optimize this, for
     /// example by using a more efficient iteration strategy (for linear reads, reduced bounds
     /// checking, etc.).
     ///
-    /// [`Traversal::iter_pos`]: layout::Traversal::iter_pos
+    /// [`Layout::iter_pos`]: layout::Layout::iter_pos
     fn iter_rect(&self, bounds: Rect) -> impl Iterator<Item = Self::Element<'_>> {
         Self::Layout::iter_pos(self.trim_rect(bounds)).filter_map(move |pos| self.get(pos))
     }

--- a/src/ops/unchecked/read.rs
+++ b/src/ops/unchecked/read.rs
@@ -2,7 +2,7 @@ use crate::{
     core::{Pos, Rect},
     ops::{
         GridBase, GridRead,
-        layout::{self, Traversal as _},
+        layout::{self, Layout as _},
         unchecked::TrustedSizeGrid,
     },
 };
@@ -15,7 +15,7 @@ pub trait GridReadUnchecked {
         Self: 'a;
 
     /// The layout of the grid, which determines how elements are stored and accessed.
-    type Layout: layout::Traversal;
+    type Layout: layout::Layout;
 
     /// Returns an element, without doing bounds checking.
     ///
@@ -47,7 +47,7 @@ pub trait GridReadUnchecked {
     ///
     /// ## Performance
     ///
-    /// The default implementation uses [`layout::Traversal::iter_pos`] to iterate over the rectangle,
+    /// The default implementation uses [`layout::Layout::iter_pos`] to iterate over the rectangle,
     /// calling [`get_unchecked`](GridReadUnchecked::get_unchecked) for each position.
     ///
     /// [undefined behavior]: https://doc.rust-lang.org/reference/behavior-considered-undefined.html

--- a/src/ops/unchecked/write.rs
+++ b/src/ops/unchecked/write.rs
@@ -2,7 +2,7 @@ use crate::{
     core::{GridError, HasSize, Pos, Rect},
     ops::{
         GridBase, GridWrite,
-        layout::{self, Traversal as _},
+        layout::{self, Layout as _},
         unchecked::TrustedSizeGrid,
     },
 };
@@ -13,7 +13,7 @@ pub trait GridWriteUnchecked {
     type Element;
 
     /// The type of layout used for the grid.
-    type Layout: layout::Traversal;
+    type Layout: layout::Layout;
 
     /// Sets the element at a specified position without bounds checking.
     ///
@@ -45,11 +45,11 @@ pub trait GridWriteUnchecked {
     ///
     /// ## Performance
     ///
-    /// The default implementation uses [`Traversal::iter_pos`] to iterate over the rectangle,
+    /// The default implementation uses [`Layout::iter_pos`] to iterate over the rectangle,
     /// calling [`set_unchecked`](GridWriteUnchecked::set_unchecked) for each position.
     ///
     /// [undefined behavior]: https://doc.rust-lang.org/reference/behavior-considered-undefined.html
-    /// [`Traversal::iter_pos`]: layout::Traversal::iter_pos
+    /// [`Layout::iter_pos`]: layout::Layout::iter_pos
     unsafe fn fill_rect_unchecked(&mut self, dst: Rect, mut f: impl FnMut(Pos) -> Self::Element) {
         Self::Layout::iter_pos(dst).for_each(|pos| unsafe {
             self.set_unchecked(pos, f(pos));
@@ -76,10 +76,10 @@ pub trait GridWriteUnchecked {
     ///
     /// ## Performance
     ///
-    /// The default implementation zips the iterator with [`Traversal::iter_pos`], calling
+    /// The default implementation zips the iterator with [`Layout::iter_pos`], calling
     /// [`set_unchecked`](GridWriteUnchecked::set_unchecked) for each yielded pair.
     ///
-    /// [`Traversal::iter_pos`]: layout::Traversal::iter_pos
+    /// [`Layout::iter_pos`]: layout::Layout::iter_pos
     unsafe fn fill_rect_iter_unchecked(
         &mut self,
         dst: Rect,

--- a/src/ops/write.rs
+++ b/src/ops/write.rs
@@ -4,7 +4,7 @@ use crate::{
     core::{GridError, Pos, Rect},
     ops::{
         ExactSizeGrid, GridBase,
-        layout::{self, Traversal as _},
+        layout::{self, Layout as _},
     },
 };
 
@@ -22,7 +22,7 @@ pub trait GridWrite: GridBase {
     /// traversal order defined by this layout.
     ///
     /// [`RowMajor`][layout::RowMajor] is a reasonable default implementation for most grids.
-    type Layout: layout::Traversal;
+    type Layout: layout::Layout;
 
     /// Sets the element at a specified position.
     ///
@@ -81,12 +81,12 @@ pub trait GridWrite: GridBase {
     ///
     /// ## Performance
     ///
-    /// The default implementation uses [`Traversal::iter_pos`] to iterate over the rectangle,
+    /// The default implementation uses [`Layout::iter_pos`] to iterate over the rectangle,
     /// involving bounds checking for each element. Other implementations may optimize this, for
     /// example by using a more efficient iteration strategy (for linear reads, reduced bounds
     /// checking, etc.).
     ///
-    /// [`Traversal::iter_pos`]: layout::Traversal::iter_pos
+    /// [`Layout::iter_pos`]: layout::Layout::iter_pos
     fn clear_rect(&mut self, bounds: Rect)
     where
         Self::Element: Default,
@@ -102,12 +102,12 @@ pub trait GridWrite: GridBase {
     ///
     /// ## Performance
     ///
-    /// The default implementation uses [`Traversal::iter_pos`] to iterate over the rectangle,
+    /// The default implementation uses [`Layout::iter_pos`] to iterate over the rectangle,
     /// involving bounds checking for each element. Other implementations may optimize this, for
     /// example by using a more efficient iteration strategy (for linear reads, reduced bounds
     /// checking, etc.).
     ///
-    /// [`Traversal::iter_pos`]: layout::Traversal::iter_pos
+    /// [`Layout::iter_pos`]: layout::Layout::iter_pos
     fn fill_rect(&mut self, bounds: Rect, mut f: impl FnMut(Pos) -> Self::Element) {
         Self::Layout::iter_pos(self.trim_rect(bounds)).for_each(|pos| {
             let _ = self.set(pos, f(pos));
@@ -125,12 +125,12 @@ pub trait GridWrite: GridBase {
     ///
     /// ## Performance
     ///
-    /// The default implementation uses [`Traversal::iter_pos`] to iterate over the rectangle,
+    /// The default implementation uses [`Layout::iter_pos`] to iterate over the rectangle,
     /// involving bounds checking for each element. Other implementations may optimize this, for
     /// example by using a more efficient iteration strategy (for linear reads, reduced bounds
     /// checking, etc.).
     ///
-    /// [`Traversal::iter_pos`]: layout::Traversal::iter_pos
+    /// [`Layout::iter_pos`]: layout::Layout::iter_pos
     fn fill_rect_iter(&mut self, dst: Rect, iter: impl IntoIterator<Item = Self::Element>) {
         Self::Layout::iter_pos(self.trim_rect(dst))
             .zip(iter)
@@ -147,12 +147,12 @@ pub trait GridWrite: GridBase {
     ///
     /// ## Performance
     ///
-    /// The default implementation uses [`Traversal::iter_pos`] to iterate over the rectangle,
+    /// The default implementation uses [`Layout::iter_pos`] to iterate over the rectangle,
     /// involving bounds checking for each element. Other implementations may optimize this, for
     /// example by using a more efficient iteration strategy (for linear reads, reduced bounds
     /// checking, etc.).
     ///
-    /// [`Traversal::iter_pos`]: layout::Traversal::iter_pos
+    /// [`Layout::iter_pos`]: layout::Layout::iter_pos
     fn fill_rect_solid(&mut self, dst: Rect, value: Self::Element)
     where
         Self::Element: Copy,

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -14,6 +14,6 @@ pub use crate::buf::{GridBuf, bits::GridBits};
 pub use crate::core::{GridError, HasSize as _, Pos, Rect, Size};
 pub use crate::ops::{
     ExactSizeGrid as _, GridBase, GridDiff as _, GridIter as _, GridRead, GridWrite, copy_rect,
-    layout::{Block, ColumnMajor, Linear as _, RowMajor, Traversal as _},
+    layout::{Block, ColumnMajor, Layout as _, LinearLayout as _, RowMajor},
 };
 pub use crate::transform::GridConvertExt as _;

--- a/src/test.rs
+++ b/src/test.rs
@@ -10,7 +10,7 @@ use crate::{
     core::{GridError, Size},
     ops::{
         GridBase, GridRead, GridWrite,
-        layout::{self, Traversal as _},
+        layout::{self, Layout as _},
     },
 };
 

--- a/src/transform.rs
+++ b/src/transform.rs
@@ -205,7 +205,7 @@ pub trait GridConvertExt: GridRead {
     fn flatten<'a, B, L>(&'a self) -> crate::buf::GridBuf<Self::Element<'a>, B, L>
     where
         B: FromIterator<Self::Element<'a>> + AsRef<[Self::Element<'a>]>,
-        L: layout::Linear,
+        L: layout::LinearLayout,
         Self: Sized,
         Self: ExactSizeGrid,
         Self::Element<'a>: Copy,


### PR DESCRIPTION
## Summary

Bumps `ixy` from `0.6.0-alpha.5` to `0.6.0-alpha.9` and applies the mechanical rename required by ixy's own breaking rename in that range:

- `layout::Traversal` -> `layout::Layout`
- `layout::Linear` -> `layout::LinearLayout` (trait bound sites throughout `buf/` and `ops/`, prelude re-export, doc comments/intra-doc links)
- `LinearLayout::pos_to_index()`/`index_to_pos()`'s second parameter renamed `width` -> `stride` (semantics unchanged); updated the custom Z-order layout example to match

`core::Size`/`core::Rect`/`HasSize` needed no changes - confirmed source-compatible since ixy's new generic `Int` parameter on `Size<T>`/`HasSize<T>` defaults to `usize`, matching grixy's existing usage throughout. No `TryFromPos`/`TryIntoPos` usage to migrate (grixy didn't use those).

Also bumps grixy's own version to `0.6.0-alpha.8` and adds a CHANGELOG entry.

This PR is scoped to just the ixy bump - no other API/architecture changes. (A separate, unrelated API refactor is queued up locally and will go up as its own PR later.)

## Verification

- `cargo test --all-features` - 129 passed (104 unit + 25 doc)
- `cargo clippy --all-features --all-targets` - pedantic, clean
- `cargo doc --all-features -D warnings` - clean
- `cargo fmt --all -- --check` - clean
- Each feature combination builds: `--no-default-features`, `buffer`, `buffer,alloc`, `serde`, `cell`, `--all-features`
