### PR TITLE
release: 0.6.0 stable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,45 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.6.0] - 2026-07-04
+
+Pre-1.0 stable release. No API breaking changes vs. alpha.8.
+
+### Added
+
+- `PartialEq`/`Eq` derives on `GridBuf<T, B, L>` (bounded on `T: PartialEq`/`Eq`, `B: PartialEq`/
+  `Eq`), so grids can be compared directly instead of manually iterating - matches what a stable
+  owning container is expected to support.
+
+### Fixed
+
+- Doc examples for `GridWrite::set()` in `ops.rs` and `prelude.rs` ignored the returned
+  `Result<(), GridError>`; they now `.unwrap()` it so the published docs model correct usage.
+- `transform` module's test suite (`Rc`/`Arc`/`GridBuf`-based) was not feature-gated and failed to
+  compile under `--no-default-features` or partial feature combinations (e.g. `--features cell`
+  alone); now gated on `feature = "buffer"` and `feature = "alloc"`, which is what it actually
+  exercises.
+
+### Chores (pre-stable pass)
+
+- Lint config aligned with the rest of the ecosystem (ixy/gem/hexal/framepace): `[lints.rust]`
+  now denies `missing_docs`/`unreachable_pub`/`unused_qualifications` (previously only
+  `missing_docs = "warn"`), and `[lints.clippy]` now denies `all`/`nursery`/`must_use_candidate`/
+  `missing_errors_doc`/`missing_panics_doc` in addition to `pedantic`. (`unsafe_code` is not
+  forbidden here, unlike sibling crates, since `grixy` legitimately uses `unsafe` for its
+  `*_unchecked` accessors.) Turning these on surfaced and fixed ~20 real findings: unnecessary
+  qualifications, `if let`/`else` that should be `Option::map_or(_else)`, redundant trait bounds,
+  `needless_collect` in tests, and one visibility lint conflict (`redundant_pub_crate` vs.
+  `unreachable_pub` disagreeing on `internal::IterRect`'s visibility - kept `pub(crate)` since
+  that's the true reachability, with a scoped `#[allow]` and comment explaining why).
+
+### Known follow-up (not blocking this release)
+
+- Non-default feature combinations still don't fully build/test cleanly beyond the one fix above
+  (e.g. `--features buffer` alone hits missing `GridBuf::new_filled` in test code elsewhere). CI
+  and this crate's own `Justfile` have only ever exercised `--all-features`, so this is pre-existing
+  and undetected, not a regression. Worth a `cargo-hack --feature-powerset` pass in a follow-up.
+
 ## [0.6.0-alpha.8] - 2026-07-03
 
 ### Dependencies

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 Pre-1.0 stable release. No API breaking changes vs. alpha.8.
 
+### Dependencies
+
+- Bumped `ixy` from the exact-pinned prerelease `=0.6.0-alpha.9` to the published stable
+  `=0.6.0`. No source changes needed; ixy's own `0.6.0` release was lint/doc/Justfile polish only.
+
 ### Added
 
 - `PartialEq`/`Eq` derives on `GridBuf<T, B, L>` (bounded on `T: PartialEq`/`Eq`, `B: PartialEq`/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,8 @@ Pre-1.0 stable release. No API breaking changes vs. alpha.8.
 ### Dependencies
 
 - Bumped `ixy` from the exact-pinned prerelease `=0.6.0-alpha.9` to the published stable
-  `=0.6.0`. No source changes needed; ixy's own `0.6.0` release was lint/doc/Justfile polish only.
+  `=0.6.1`. No source changes needed; ixy's `0.6.0`/`0.6.1` releases were lint/doc/Justfile
+  polish plus a docs.rs build fix (`doc_auto_cfg` removed upstream).
 
 ### Added
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -409,9 +409,9 @@ checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
 
 [[package]]
 name = "ixy"
-version = "0.6.0-alpha.9"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf5db685a29892d524bda3513508e53a4949e452ad4112e9ee5bb13794337b59"
+checksum = "feac696feeae45437701a855926f1774028ce7acbf2ba8af2792debe64e866d9"
 dependencies = [
  "serde",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -320,7 +320,7 @@ dependencies = [
 
 [[package]]
 name = "grixy"
-version = "0.6.0-alpha.8"
+version = "0.6.0"
 dependencies = [
  "bytemuck",
  "criterion",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -409,9 +409,9 @@ checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
 
 [[package]]
 name = "ixy"
-version = "0.6.0"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "feac696feeae45437701a855926f1774028ce7acbf2ba8af2792debe64e866d9"
+checksum = "947712713bffab262e4ef564ace3eadecc59d041244c566bcc2e7d1d43dff5cf"
 dependencies = [
  "serde",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,7 +48,7 @@ serde = ["dep:serde", "ixy/serde"]
 all-features = true
 
 [dependencies]
-ixy = { version = "=0.6.0" }
+ixy = { version = "=0.6.1" }
 serde = { version = "1.0", optional = true, features = ["derive"] }
 
 [dev-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,13 +10,21 @@ rust-version = "1.87"
 documentation = "https://docs.rs/grixy"
 keywords = ["2d", "grid", "embedded", "no-std", "gamedev"]
 categories = ["game-development", "mathematics", "embedded", "no-std"]
-version = "0.6.0-alpha.8"
+version = "0.6.0"
 
 [lints.rust]
-missing_docs = "warn"
+missing_docs = "deny"
+unreachable_pub = "deny"
+unused_qualifications = "deny"
 
 [lints.clippy]
-pedantic = "deny"
+all = { level = "deny", priority = -1 }
+pedantic = { level = "deny", priority = -1 }
+nursery = { level = "deny", priority = -1 }
+must_use_candidate = "deny"
+missing_errors_doc = "deny"
+missing_panics_doc = "deny"
+module_name_repetitions = "allow"
 
 [workspace]
 members = ["tools/cargo-bin"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,7 +48,7 @@ serde = ["dep:serde", "ixy/serde"]
 all-features = true
 
 [dependencies]
-ixy = { version = "=0.6.0-alpha.9" }
+ixy = { version = "=0.6.0" }
 serde = { version = "1.0", optional = true, features = ["derive"] }
 
 [dev-dependencies]

--- a/TODO.md
+++ b/TODO.md
@@ -16,10 +16,15 @@ _Nothing as of now_.
 - [x] Add an example of a grid with a custom layout (`examples/z-order.rs`)
 - [x] Benchmark heavily and adjust as needed
 
-## 0.6.0 (Stable)
+## Post-0.6.0
 
-- [ ] Implement some nice debug string representations/formats
+`0.6.0` shipped without these; `Display for GridBuf` already landed in alpha.6 and covers the
+most common debug-string need, so these were judged non-blocking for the stable tag.
+
+- [ ] Implement some nice debug string representations/formats (beyond the existing `Display`)
 - [ ] Test coverage back to 100%, fix bugs as they come up
+- [ ] `cargo-hack --feature-powerset` in CI/Justfile - non-default feature combinations aren't
+  currently built/tested (see 0.6.0 CHANGELOG's "Known follow-up")
 
 ## Future
 

--- a/src/buf.rs
+++ b/src/buf.rs
@@ -43,7 +43,7 @@ mod impl_slice;
 /// [`Layout`].
 ///
 /// [`Layout`]: layout::Layout
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct GridBuf<T, B, L> {
     buffer: B,
     width: usize,
@@ -179,7 +179,7 @@ mod tests {
     #[test]
     fn rect_iter_unchecked() {
         #[rustfmt::skip]
-        let buffer = GridBuf::<_, _, layout::RowMajor>::from_buffer(vec![
+        let buffer = GridBuf::<_, _, RowMajor>::from_buffer(vec![
             1, 2, 3,
             4, 5, 6,
             7, 8, 9,

--- a/src/buf/bits.rs
+++ b/src/buf/bits.rs
@@ -218,18 +218,21 @@ where
         &self,
         bounds: crate::prelude::Rect,
     ) -> impl Iterator<Item = Self::Element<'_>> {
-        if let Some(aligned) = L::slice_rect_aligned(self.as_ref(), self.size(), bounds) {
-            let iter = aligned.iter().flat_map(|byte| {
-                (0..T::MAX_WIDTH).map(move |bit_index| (byte.to_usize() >> bit_index) & 1 != 0)
-            });
-            internal::IterRect::Aligned(iter)
-        } else {
-            let iter = {
-                let pos = Self::Layout::iter_pos(bounds);
-                pos.map(move |pos| unsafe { self.get_unchecked(pos) })
-            };
-            internal::IterRect::Unaligned(iter)
-        }
+        L::slice_rect_aligned(self.as_ref(), self.size(), bounds).map_or_else(
+            || {
+                let iter = {
+                    let pos = Self::Layout::iter_pos(bounds);
+                    pos.map(move |pos| unsafe { self.get_unchecked(pos) })
+                };
+                internal::IterRect::Unaligned(iter)
+            },
+            |aligned| {
+                let iter = aligned.iter().flat_map(|byte| {
+                    (0..T::MAX_WIDTH).map(move |bit_index| (byte.to_usize() >> bit_index) & 1 != 0)
+                });
+                internal::IterRect::Aligned(iter)
+            },
+        )
     }
 }
 
@@ -260,7 +263,7 @@ where
     B: AsRef<[T]>,
     L: layout::LinearLayout,
 {
-    fn size_hint(&self) -> (crate::prelude::Size, Option<crate::prelude::Size>) {
+    fn size_hint(&self) -> (Size, Option<Size>) {
         let size = Size::new(self.width, self.height);
         (size, Some(size))
     }

--- a/src/buf/bits/ops.rs
+++ b/src/buf/bits/ops.rs
@@ -1,6 +1,5 @@
 use core::{
     fmt::Debug,
-    mem,
     ops::{BitAnd, BitAndAssign, BitOrAssign, Not},
 };
 
@@ -18,7 +17,7 @@ pub trait BitOps:
     + Not<Output = Self>
 {
     /// The maximum width that can be represented by this type.
-    const MAX_WIDTH: usize = mem::size_of::<Self>() * 8;
+    const MAX_WIDTH: usize = size_of::<Self>() * 8;
 
     /// Converts a `usize` into this type.
     ///

--- a/src/buf/impl_grid.rs
+++ b/src/buf/impl_grid.rs
@@ -12,7 +12,7 @@ impl<T, B, L> GridBase for GridBuf<T, B, L>
 where
     L: layout::LinearLayout,
 {
-    fn size_hint(&self) -> (crate::prelude::Size, Option<crate::prelude::Size>) {
+    fn size_hint(&self) -> (Size, Option<Size>) {
         let size = Size::new(self.width, self.height);
         (size, Some(size))
     }
@@ -60,22 +60,25 @@ where
         &self,
         bounds: crate::core::Rect,
     ) -> impl Iterator<Item = Self::Element<'_>> {
-        if let Some(aligned) = L::slice_rect_aligned(self.as_ref(), self.size(), bounds) {
-            // SAFETY: `slice_rect_aligned` returns `None` when the bounds are not contiguous in
-            // the layout's storage order. When it returns `Some`, the returned slice covers
-            // exactly the positions in `bounds`. The caller guarantees every position is valid,
-            // so the slice is within the allocated buffer.
-            internal::IterRect::Aligned(aligned.iter())
-        } else {
-            // SAFETY: For non-contiguous rects, iterate position-by-position. Each
-            // `self.get_unchecked(pos)` call is sound because the caller guarantees all
-            // positions in `bounds` are valid.
-            let iter = {
-                let pos = L::iter_pos(bounds);
-                pos.map(move |pos| unsafe { self.get_unchecked(pos) })
-            };
-            internal::IterRect::Unaligned(iter)
-        }
+        L::slice_rect_aligned(self.as_ref(), self.size(), bounds).map_or_else(
+            || {
+                // SAFETY: For non-contiguous rects, iterate position-by-position. Each
+                // `self.get_unchecked(pos)` call is sound because the caller guarantees all
+                // positions in `bounds` are valid.
+                let iter = {
+                    let pos = L::iter_pos(bounds);
+                    pos.map(move |pos| unsafe { self.get_unchecked(pos) })
+                };
+                internal::IterRect::Unaligned(iter)
+            },
+            |aligned| {
+                // SAFETY: `slice_rect_aligned` returns `None` when the bounds are not contiguous in
+                // the layout's storage order. When it returns `Some`, the returned slice covers
+                // exactly the positions in `bounds`. The caller guarantees every position is valid,
+                // so the slice is within the allocated buffer.
+                internal::IterRect::Aligned(aligned.iter())
+            },
+        )
     }
 }
 

--- a/src/core.rs
+++ b/src/core.rs
@@ -34,7 +34,7 @@ pub enum GridError {
 impl Display for GridError {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         match self {
-            GridError::OutOfBounds { pos } => write!(f, "Position out of bounds: {pos}"),
+            Self::OutOfBounds { pos } => write!(f, "Position out of bounds: {pos}"),
         }
     }
 }

--- a/src/internal.rs
+++ b/src/internal.rs
@@ -4,6 +4,12 @@ pub trait Sealed {}
 
 /// The result of iterating over a rectangular region of a grid.
 #[allow(dead_code)]
+// `redundant_pub_crate` and `unreachable_pub` disagree on the right visibility for an item in a
+// `pub(crate)` module: the former wants `pub` (since the enclosing module is already crate-
+// private), the latter flags `pub` as unreachable outside the crate and wants `pub(crate)`.
+// `unreachable_pub` reflects the truth (nothing outside this crate can see `IterRect`), so keep
+// `pub(crate)` and allow the redundancy lint here.
+#[allow(clippy::redundant_pub_crate)]
 pub(crate) enum IterRect<T, A, U>
 where
     A: Iterator<Item = T>,
@@ -25,15 +31,15 @@ where
 
     fn next(&mut self) -> Option<Self::Item> {
         match self {
-            IterRect::Aligned(iter) => iter.next(),
-            IterRect::Unaligned(iter) => iter.next(),
+            Self::Aligned(iter) => iter.next(),
+            Self::Unaligned(iter) => iter.next(),
         }
     }
 
     fn size_hint(&self) -> (usize, Option<usize>) {
         match self {
-            IterRect::Aligned(iter) => iter.size_hint(),
-            IterRect::Unaligned(iter) => iter.size_hint(),
+            Self::Aligned(iter) => iter.size_hint(),
+            Self::Unaligned(iter) => iter.size_hint(),
         }
     }
 }

--- a/src/ops.rs
+++ b/src/ops.rs
@@ -51,7 +51,7 @@
 //!   width: 10,
 //! };
 //!
-//! my_grid.set(Pos::new(5, 5), 42);
+//! my_grid.set(Pos::new(5, 5), 42).unwrap();
 //! assert_eq!(my_grid.grid[55], 42);
 //! ```
 

--- a/src/ops/base.rs
+++ b/src/ops/base.rs
@@ -41,11 +41,9 @@ pub trait GridBase {
     /// The default implementation intersects the rectangle with the upper bound of `size_hint()`.
     fn trim_rect(&self, rect: Rect) -> Rect {
         let (_, max) = self.size_hint();
-        if let Some(max) = max {
+        max.map_or(rect, |max| {
             rect.intersect(Rect::from_tl_size(Pos::ORIGIN, max))
-        } else {
-            rect
-        }
+        })
     }
 }
 

--- a/src/ops/diff.rs
+++ b/src/ops/diff.rs
@@ -68,8 +68,7 @@ mod tests {
     fn diff_same_grid() {
         let a = GridBuf::new_filled(3, 3, 0u8);
         let b = GridBuf::new_filled(3, 3, 0u8);
-        let changed: Vec<_> = a.diff(&b).collect();
-        assert!(changed.is_empty());
+        assert!(a.diff(&b).next().is_none());
     }
 
     #[test]
@@ -98,7 +97,6 @@ mod tests {
         let b = GridBuf::new_filled(3, 3, 0u8);
 
         // All positions in self (2x2) are considered changed
-        let changed: Vec<_> = a.diff(&b).collect();
-        assert_eq!(changed.len(), 4);
+        assert_eq!(a.diff(&b).count(), 4);
     }
 }

--- a/src/ops/read.rs
+++ b/src/ops/read.rs
@@ -171,10 +171,7 @@ mod tests {
         let grid = CheckedGridTest {
             grid: [[1, 2, 3], [4, 5, 6], [7, 8, 9]],
         };
-        let cells = grid
-            .iter_rect(Rect::from_ltwh(3, 3, 2, 2))
-            .collect::<Vec<_>>();
-        assert!(cells.is_empty());
+        assert!(grid.iter_rect(Rect::from_ltwh(3, 3, 2, 2)).next().is_none());
     }
 
     #[test]

--- a/src/ops/unchecked/read.rs
+++ b/src/ops/unchecked/read.rs
@@ -196,9 +196,6 @@ mod tests {
         let grid = UncheckedTestGrid {
             grid: [[1, 2, 3], [4, 5, 6], [7, 8, 9]],
         };
-        let cells = grid
-            .iter_rect(Rect::from_ltwh(3, 3, 2, 2))
-            .collect::<Vec<_>>();
-        assert!(cells.is_empty());
+        assert!(grid.iter_rect(Rect::from_ltwh(3, 3, 2, 2)).next().is_none());
     }
 }

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -4,7 +4,7 @@
 //! use grixy::prelude::*;
 //!
 //! let mut grid = GridBuf::<u8, _, _>::new(5, 5);
-//! grid.set(Pos::new(4, 4), 42);
+//! grid.set(Pos::new(4, 4), 42).unwrap();
 //!
 //! assert_eq!(grid.get(Pos::new(4, 4)), Some(&42));
 //! ```

--- a/src/test.rs
+++ b/src/test.rs
@@ -96,7 +96,7 @@ impl<T> GridWrite for NaiveGrid<T> {
 
 impl<T> IntoIterator for NaiveGrid<T> {
     type Item = T;
-    type IntoIter = alloc::vec::IntoIter<T>;
+    type IntoIter = vec::IntoIter<T>;
 
     fn into_iter(self) -> Self::IntoIter {
         self.cells.into_iter()

--- a/src/transform.rs
+++ b/src/transform.rs
@@ -206,8 +206,7 @@ pub trait GridConvertExt: GridRead {
     where
         B: FromIterator<Self::Element<'a>> + AsRef<[Self::Element<'a>]>,
         L: layout::LinearLayout,
-        Self: Sized,
-        Self: ExactSizeGrid,
+        Self: Sized + ExactSizeGrid,
         Self::Element<'a>: Copy,
     {
         use crate::core::Rect;
@@ -235,7 +234,7 @@ pub trait GridConvertExt: GridRead {
     /// ```
     fn blend<F>(&mut self, blend_fn: F) -> Blended<'_, Self, F>
     where
-        Self: Sized + GridRead + GridWrite,
+        Self: Sized + GridWrite,
         F: Fn(
             <Self as GridRead>::Element<'_>,
             <Self as GridWrite>::Element,
@@ -250,7 +249,11 @@ pub trait GridConvertExt: GridRead {
 
 impl<T> GridConvertExt for T where T: GridRead {}
 
-#[cfg(test)]
+// The whole module exercises `GridBuf` (requires `buffer`) and `alloc::{rc, sync}` (requires
+// `alloc`), so gate it accordingly rather than assuming `--all-features` like the rest of the
+// crate's tests happen to (this is what let a `--no-default-features`/partial-feature build
+// silently fail to compile its own test suite).
+#[cfg(all(test, feature = "buffer", feature = "alloc"))]
 mod tests {
     extern crate alloc;
 

--- a/src/transform/viewed.rs
+++ b/src/transform/viewed.rs
@@ -17,7 +17,7 @@ impl<G> GridBase for Viewed<G>
 where
     G: GridBase,
 {
-    fn size_hint(&self) -> (Size, Option<crate::core::Size>) {
+    fn size_hint(&self) -> (Size, Option<Size>) {
         let size = Size::new(self.bounds.width(), self.bounds.height());
         (size, Some(size))
     }


### PR DESCRIPTION
Promotes grixy to a stable-but-pre-1.0 `0.6.0` release. No API breaking changes vs. alpha.8 (one additive derive).

## Changes

- **Lint config aligned with the rest of the ecosystem** (ixy/gem/hexal/framepace): `[lints.rust]` now denies `missing_docs`/`unreachable_pub`/`unused_qualifications` (previously only `missing_docs = "warn"`), and `[lints.clippy]` now denies `all`/`nursery`/`must_use_candidate`/`missing_errors_doc`/`missing_panics_doc` in addition to `pedantic`. (`unsafe_code` is intentionally *not* forbidden, unlike sibling crates - grixy legitimately uses `unsafe` for its `*_unchecked` accessors.) Turning these on surfaced and fixed ~20 real findings: unnecessary qualifications, `if let`/`else` that should be `Option::map_or(_else)`, redundant trait bounds, `needless_collect` in tests, and one visibility-lint conflict on `internal::IterRect` (kept `pub(crate)`, which is the true reachability, with a scoped `#[allow(clippy::redundant_pub_crate)]` and a comment explaining the conflict).
- **`GridBuf<T, B, L>` now derives `PartialEq`/`Eq`** in addition to `Debug`/`Clone` - a real gap for a stable owning container (you couldn't previously assert two grids are equal without manually iterating).
- **Fixed doc-example hygiene**: `ops.rs` and `prelude.rs` doc examples called `.set()` (returns `Result<(), GridError>`) without handling the result, teaching users to drop errors. Now `.unwrap()`'d.
- **Fixed a real feature-gating bug found while turning on the stricter lints**: `transform`'s test module (uses `Rc`/`Arc`/`GridBuf`) wasn't feature-gated and failed to compile under `--no-default-features` or partial feature combinations. Now gated on `feature = "buffer"` and `feature = "alloc"`, matching what it actually exercises.
- Version bump to `0.6.0`, CHANGELOG entry, `TODO.md` reconciled (moved unshipped `0.6.0 (Stable)` items to a `Post-0.6.0` section with rationale).

## Known follow-up (not blocking this release)

Non-default feature combinations still don't fully build/test cleanly beyond the one fix above (e.g. `--features buffer` alone hits a missing `GridBuf::new_filled` in unrelated test code). CI and this crate's own `Justfile` have only ever exercised `--all-features`, so this is pre-existing and previously undetected, not a regression from this PR. Tracked in `TODO.md` as a `cargo-hack --feature-powerset` follow-up.

## Downstream coordination

`ixy` is now bumped to the published stable `=0.6.0` (ixy's 0.6.0 release: https://github.com/crates-lurey-io/ixy/pull/7, published to crates.io). Verified grixy builds/lints/tests clean against the real published dependency, not just a local path patch.

Full readiness review: `.matan/next.md` in this repo (gitignored, not part of this diff).

Verified: `cargo build/clippy/fmt/test/doc --all-features` all clean; MSRV `1.87` build verified with the `1.87` toolchain.