### PR TITLE
fix: default feature set must actually compile (cargo publish verification)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,13 @@ Pre-1.0 stable release. No API breaking changes vs. alpha.8.
 
 ### Fixed
 
+- `cargo publish`'s own verification build (default features) failed to compile:
+  `internal::Sealed` was unconditionally `pub`, but it's only reachable from the public API
+  surface (as a supertrait bound on `buf::bits::ops::BitOps`) when the `buffer` feature is
+  enabled, so `unreachable_pub` fired under the default feature set. Fixed by defining `Sealed`
+  at the visibility each feature configuration actually needs (`pub` under `buffer`, `pub(crate)`
+  otherwise) instead of picking one and living with a lint conflict. Verified with `cargo package`
+  (what `cargo publish` runs for verification), not just `cargo build --all-features`.
 - Doc examples for `GridWrite::set()` in `ops.rs` and `prelude.rs` ignored the returned
   `Result<(), GridError>`; they now `.unwrap()` it so the published docs model correct usage.
 - `transform` module's test suite (`Rc`/`Arc`/`GridBuf`-based) was not feature-gated and failed to

--- a/src/internal.rs
+++ b/src/internal.rs
@@ -1,6 +1,21 @@
 /// Prevents a trait from being implemented outside this crate.
+///
+/// Its required visibility is feature-conditional: `buf::bits::ops::BitOps` (a `pub` trait) uses
+/// `Sealed` as a supertrait bound only when the `buffer` feature is enabled, which requires
+/// `Sealed` to be at least `pub` too (`private_bounds`). Without `buffer`, nothing in the public
+/// API surface reaches `Sealed` at all, so a plain `pub` trips `unreachable_pub` instead. Define
+/// it at the visibility each configuration actually needs rather than picking one and allowing
+/// the other lint.
+#[cfg(feature = "buffer")]
 #[allow(dead_code)]
 pub trait Sealed {}
+
+#[cfg(not(feature = "buffer"))]
+#[allow(dead_code)]
+// See the redundant_pub_crate/unreachable_pub conflict note on `IterRect` below - same conflict,
+// same resolution.
+#[allow(clippy::redundant_pub_crate)]
+pub(crate) trait Sealed {}
 
 /// The result of iterating over a rectangular region of a grid.
 #[allow(dead_code)]


### PR DESCRIPTION
Caught before tagging/publishing `0.6.0`: `cargo package` (what `cargo publish` runs for verification) failed to compile the default feature set:

```
error: unreachable `pub` item
 --> src/internal.rs:3:1
  |
3 | pub trait Sealed {}
  |
  = note: requested on the command line with `-D unreachable-pub`
error: could not compile `grixy` (lib) due to 1 previous error
error: failed to verify package tarball
```

Same class of bug as gem's `0.1.0` -> `0.1.1` publish-verification fix ([gem#6](https://github.com/crates-lurey-io/gem/pull/6)): `internal::Sealed` was unconditionally `pub`, but it's only reachable from the public API surface (as a supertrait bound on `buf::bits::ops::BitOps`) when the `buffer` feature is enabled. Under the default feature set nothing reaches it, so `unreachable_pub` fires. Under `--all-features` it's reachable, so `cargo build --all-features`/CI never caught this (matches the "Known follow-up" gap already noted in the `0.6.0` CHANGELOG entry about non-default feature combinations).

## Fix

Define `Sealed` at the visibility each feature configuration actually needs, instead of picking one and living with the lint conflict:

```rust
#[cfg(feature = "buffer")]
pub trait Sealed {}

#[cfg(not(feature = "buffer"))]
pub(crate) trait Sealed {}
```

This resolves the three-way conflict between `unreachable_pub` (wants `pub(crate)` without `buffer`), `private_bounds` (wants `pub` with `buffer`, since `BitOps` is a public trait using `Sealed` as a supertrait bound), and `redundant_pub_crate` (wants `pub` in a `pub(crate)` module) - each variant only needs one scoped `#[allow]` for the lint that's still a false positive for that configuration.

Verified: `cargo build` (default), `cargo build/clippy/fmt/test/doc --all-features`, and `cargo package` all pass clean.

No API-visible change (only affects a `pub(crate)`-module-internal sealing trait).
