### PR TITLE
chore: relax ixy dependency to a normal caret requirement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,21 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.6.1] - 2026-07-04
+
+### Dependencies
+
+- Relaxed `ixy` from an exact `=0.6.1` pin to a normal caret requirement (`"0.6.1"`). The exact
+  pin was a necessary workaround while `ixy` was still on its `0.6.0-alpha.N` prerelease track,
+  where Cargo's caret matching against prereleases is unsafe (a caret pinned to one prerelease can
+  silently resolve to a later, breaking prerelease of the same version). Now that `ixy` has a real
+  stable release, normal Cargo `0.y.z` caret semantics apply and are already safe: caret only
+  floats the patch (`z`) component, never the `y`, so it can't silently jump to a breaking `0.7.0`.
+  Keeping the exact pin post-stabilization only costs: every future `ixy` patch (like `0.6.1`'s
+  docs.rs fix) would force a synchronized `grixy` republish, and it risks unresolvable
+  version-unification failures for any consumer that depends on both `ixy` and `grixy` directly
+  with even slightly different exact pins.
+
 ## [0.6.0] - 2026-07-04
 
 Pre-1.0 stable release. No API breaking changes vs. alpha.8.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -320,7 +320,7 @@ dependencies = [
 
 [[package]]
 name = "grixy"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "bytemuck",
  "criterion",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ rust-version = "1.87"
 documentation = "https://docs.rs/grixy"
 keywords = ["2d", "grid", "embedded", "no-std", "gamedev"]
 categories = ["game-development", "mathematics", "embedded", "no-std"]
-version = "0.6.0"
+version = "0.6.1"
 
 [lints.rust]
 missing_docs = "deny"
@@ -48,7 +48,7 @@ serde = ["dep:serde", "ixy/serde"]
 all-features = true
 
 [dependencies]
-ixy = { version = "=0.6.1" }
+ixy = { version = "0.6.1" }
 serde = { version = "1.0", optional = true, features = ["derive"] }
 
 [dev-dependencies]


### PR DESCRIPTION
Relaxes `ixy` from an exact `=0.6.1` pin to a normal caret requirement (`"0.6.1"`).

The exact pin was a necessary workaround while `ixy` was still on its `0.6.0-alpha.N` prerelease track, where Cargo's caret matching against prereleases is unsafe: a caret requirement pinned to one prerelease can silently resolve to a later, breaking prerelease of the *same* version number (this is exactly what happened before grixy's alpha.8, and what hexal's own `Cargo.lock` had already silently drifted into before its own release).

Now that `ixy` has a real stable release, normal Cargo `0.y.z` caret semantics apply and are already safe: caret only floats the patch (`z`) component, never `y`, so `ixy = "0.6.1"` can never silently jump to a breaking `0.7.0` - Cargo treats the `y` in `0.y.z` as if it were the major version for compatibility purposes.

Keeping the exact pin post-stabilization only has downsides:

1. Every future `ixy` patch release forces a synchronized `grixy` republish - this literally just happened when `ixy`'s `0.6.1` docs.rs fix required bumping and republishing `grixy`.
2. It risks unresolvable version-unification failures for any consumer that depends on both `ixy` and `grixy` directly, if their exact pins ever diverge even slightly.

Patch release: `0.6.1`. No API or behavior change.

Verified: `cargo build/clippy/fmt/test --all-features` and `cargo package` (publish verification) all pass clean.
