### PR TITLE
fix: copy_rect misaligns rows when either rect clips

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,21 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.6.2] - 2026-08-02
+
+### Fixed
+
+- `ops::draw::copy_rect` misaligned rows whenever either the source or the destination rectangle
+  clipped. The implementation zipped a lazily filter-mapped source value stream against a
+  separately computed destination position stream; when either side dropped a cell (because it
+  was out of bounds), the two streams desynced and every subsequent cell in the zip shifted by
+  one, corrupting the rest of the copy instead of just skipping the clipped cell. Fixed by pairing
+  each source position with its destination position by a fixed offset and copying them one at a
+  time via `get`/`set`, so an out-of-bounds cell on either side is skipped in place - matching what
+  the function's own docs already claimed ("those individual cells are ignored"). No API change;
+  `trim_rect` is still used to narrow the candidate area as an optimization where a grid's
+  `size_hint` supports it, but correctness no longer depends on it.
+
 ## [0.6.1] - 2026-07-04
 
 ### Dependencies

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -320,7 +320,7 @@ dependencies = [
 
 [[package]]
 name = "grixy"
-version = "0.6.1"
+version = "0.6.2"
 dependencies = [
  "bytemuck",
  "criterion",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ rust-version = "1.87"
 documentation = "https://docs.rs/grixy"
 keywords = ["2d", "grid", "embedded", "no-std", "gamedev"]
 categories = ["game-development", "mathematics", "embedded", "no-std"]
-version = "0.6.1"
+version = "0.6.2"
 
 [lints.rust]
 missing_docs = "deny"

--- a/src/ops/draw.rs
+++ b/src/ops/draw.rs
@@ -29,17 +29,26 @@ pub fn copy_rect<'a, E>(
     from: Rect,
     to: Pos,
 ) {
-    dst.fill_rect_iter(
-        Rect::from_ltwh(to.x, to.y, from.width(), from.height()),
-        src.iter_rect(from),
-    );
+    // Pair up each source position with its destination position by offset and copy them one at
+    // a time, rather than zipping a (possibly shorter, clip-filtered) value stream against a
+    // separate position stream: if either side drops a cell, a zip desyncs and shifts every
+    // subsequent cell in the row. `trim_rect` only narrows the candidate area as an optimization;
+    // out-of-bounds cells are still skipped individually via `get`/`set`.
+    let from = src.trim_rect(from);
+    for src_pos in from.pos_iter() {
+        let Some(value) = src.get(src_pos) else {
+            continue;
+        };
+        let dst_pos = to + (src_pos - from.top_left());
+        let _ = dst.set(dst_pos, value);
+    }
 }
 
 #[cfg(test)]
 mod tests {
     extern crate alloc;
 
-    use crate::{test::NaiveGrid, transform::GridConvertExt as _};
+    use crate::{ops::GridBase, test::NaiveGrid, transform::GridConvertExt as _};
     use alloc::vec::Vec;
 
     use super::*;
@@ -97,6 +106,91 @@ mod tests {
             0, 0, 0, 0, 0,
             0, 0, 0, 0, 0,
             0, 0, 0, 0, 1,
+        ]);
+    }
+
+    #[test]
+    fn copy_rect_row_alignment_when_destination_clips() {
+        // Exact reproduction from https://github.com/crates-lurey-io/grixy/issues/15: a 3x3
+        // source copied to (3, 3) of a 5x5 destination clips on the right/bottom. Previously this
+        // shifted every row after the first because the destination `set` calls that landed
+        // out-of-bounds silently desynced a zipped value stream instead of being skipped in place.
+        #[rustfmt::skip]
+        let src = NaiveGrid::<i32>::with_cells(3, 3, [
+            1, 2, 3,
+            4, 5, 6,
+            7, 8, 9,
+        ]);
+
+        let mut dst = NaiveGrid::<i32>::new(5, 5);
+        copy_rect(
+            &src.copied(),
+            &mut dst,
+            Rect::from_ltwh(0, 0, 3, 3),
+            Pos::new(3, 3),
+        );
+
+        #[rustfmt::skip]
+        assert_eq!(dst.into_iter().collect::<Vec<_>>(),
+        &[
+            0, 0, 0, 0, 0,
+            0, 0, 0, 0, 0,
+            0, 0, 0, 0, 0,
+            0, 0, 0, 1, 2,
+            0, 0, 0, 4, 5,
+        ]);
+    }
+
+    /// A grid with no size hint (uses [`GridBase`]'s default), so `trim_rect` never narrows
+    /// `from` ahead of time. Used to exercise `copy_rect`'s per-position `get`-returns-`None`
+    /// handling directly, rather than relying on `trim_rect` to clamp `from` to the source's real
+    /// bounds before iteration ever reaches an out-of-bounds position.
+    struct UnhintedGrid<'a>(&'a NaiveGrid<i32>);
+
+    impl GridBase for UnhintedGrid<'_> {}
+
+    impl GridRead for UnhintedGrid<'_> {
+        type Element<'b>
+            = i32
+        where
+            Self: 'b;
+
+        type Layout = crate::ops::layout::RowMajor;
+
+        fn get(&self, pos: Pos) -> Option<Self::Element<'_>> {
+            self.0.get(pos).copied()
+        }
+    }
+
+    #[test]
+    fn copy_rect_row_alignment_when_source_clips_mid_row() {
+        #[rustfmt::skip]
+        let src = NaiveGrid::<i32>::with_cells(3, 3, [
+            1, 2, 3,
+            4, 5, 6,
+            7, 8, 9,
+        ]);
+        let unhinted = UnhintedGrid(&src);
+
+        let mut dst = NaiveGrid::<i32>::new(5, 5);
+        // `from` extends past the (unhinted) source's real 3x3 bounds on the right, and
+        // `trim_rect` can't narrow it away (no size hint), so `get` returns `None` for the
+        // clipped column on every row.
+        copy_rect(
+            &unhinted,
+            &mut dst,
+            Rect::from_ltwh(0, 0, 4, 3),
+            Pos::new(0, 0),
+        );
+
+        #[rustfmt::skip]
+        assert_eq!(dst.into_iter().collect::<Vec<_>>(),
+        &[
+            1, 2, 3, 0, 0,
+            4, 5, 6, 0, 0,
+            7, 8, 9, 0, 0,
+            0, 0, 0, 0, 0,
+            0, 0, 0, 0, 0,
         ]);
     }
 


### PR DESCRIPTION
Fixes #15.

`ops::draw::copy_rect` zipped a lazily filter-mapped source value stream
(`src.iter_rect(from)`) against a separately computed destination position
stream (`dst.fill_rect_iter`'s internal position iterator). When either side
dropped a cell because it was out of bounds, the two streams desynced and every
subsequent cell in the row shifted over by one, instead of just the clipped
cell being skipped.

Repro from the issue: a 3x3 source `1..=9` copied to `(3, 3)` of a 5x5
destination (clips on the right/bottom):

```
dst row 3 = [0, 0, 0, 1, 2]   correct (unaffected, first row)
dst row 4 = [0, 0, 0, 3, 4]   wrong, was shifted, should be [0, 0, 0, 4, 5]
```

## Fix

Pair each source position with its destination position via a fixed offset
(`to + (src_pos - from.top_left())`) and copy them one at a time through
`get`/`set`, so an out-of-bounds cell on either side is skipped in place
without disturbing any other cell. This also happens to make the
implementation match what its own doc comment already claimed ("those
individual cells are ignored and not copied to/from"); that was previously
aspirational, not actually true.

No API change: same signature, same trait bounds. `trim_rect` is still used
upfront to narrow the candidate area as an optimization on grids with an
accurate `size_hint`, but correctness no longer depends on it being accurate
(a grid with no size hint at all is exercised in the new
`copy_rect_row_alignment_when_source_clips_mid_row` test, via a local
`UnhintedGrid` fixture, to prove the per-position fallback is correct too).

## Testing

- `copy_rect_row_alignment_when_destination_clips`: exact reproduction from
  the issue, sequential values, verifies the destination-side clip no longer
  shifts row 4.
- `copy_rect_row_alignment_when_source_clips_mid_row`: source-side clip
  (via a grid with no size hint, so `trim_rect` can't help), sequential
  values, verifies a `None` mid-row doesn't shift subsequent cells.
- All existing `copy_rect` tests still pass unchanged.
- `cargo just check` (fmt, clippy `-D warnings`, doc-check) and
  `cargo just test-all` (unit + doctests) both pass.

Bumped `0.6.1` -> `0.6.2` (bug fix, no API change) with a CHANGELOG entry.
