### PR TITLE
fix: Viewed::get double-offset bounds + add copy_rect_clamped (0.6.2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.6.2] - 2026-08-02
 
+### Added
+
+- `ops::draw::copy_rect_clamped`, a variant of `copy_rect` bounded on `ExactSizeGrid` (in addition
+  to `GridRead`/`GridWrite`). `from` is clamped to the source grid's bounds, the equivalent
+  destination rectangle is translated from that clamp and clamped again to the destination grid's
+  bounds, and the resulting equal-sized rectangles are copied position-for-position. Because both
+  clamps use the grid's authoritative size instead of `GridBase::trim_rect`'s best-effort hint, the
+  copy is always bounded to the actual overlapping region - useful when `from` may be much larger
+  than the source's real bounds and the source has no accurate `size_hint`. Exported from `ops` and
+  the prelude alongside `copy_rect`.
+
 ### Fixed
 
 - `ops::draw::copy_rect` misaligned rows whenever either the source or the destination rectangle
@@ -19,6 +30,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   the function's own docs already claimed ("those individual cells are ignored"). No API change;
   `trim_rect` is still used to narrow the candidate area as an optimization where a grid's
   `size_hint` supports it, but correctness no longer depends on it.
+- `transform::Viewed::get` double-offset `pos`: it translated `pos` by subtracting
+  `bounds.top_left()` and then checked the *already-translated* position against the
+  *untranslated* `bounds`, which only happened to work when `bounds.top_left() == Pos::ORIGIN`
+  (the only case the crate's own tests covered) and underflow-panicked for any `pos` smaller than
+  `bounds.top_left()`. `Viewed::iter_rect` had the same directional bug (translating by
+  subtracting instead of adding) plus no clamping, so it could both panic and leak cells from
+  outside the view. Fixed by treating the incoming position/rect as view-local (checking it
+  against the view's own zero-based size, or clamping via `trim_rect`, before adding
+  `bounds.top_left()` to reach the source's coordinate space).
 
 ## [0.6.1] - 2026-07-04
 

--- a/benches/blit.rs
+++ b/benches/blit.rs
@@ -77,7 +77,7 @@ fn blit_grid(pixels: Vec<u32>) -> Vec<u32> {
 
     // Read each glyph from the font and copy it to the canvas in reverse order.
     for i in (0..256).rev() {
-        copy_rect(
+        copy_rect_clamped(
             &src,
             &mut dst,
             Rect::from_ltwh(0, i * 8, 8, 8),

--- a/examples/mono-font-raster.rs
+++ b/examples/mono-font-raster.rs
@@ -28,7 +28,7 @@ fn main() {
         let y = (i / 16) * 8 * scale;
 
         // Draws the glyph onto the canvas at the specified position.
-        copy_rect(
+        copy_rect_clamped(
             &font,
             &mut canvas,
             Rect::from_ltwh(0, i * 8 * scale, 8 * scale, 8 * scale),

--- a/src/ops.rs
+++ b/src/ops.rs
@@ -72,6 +72,6 @@ mod write;
 
 pub use base::{ExactSizeGrid, GridBase};
 pub use diff::GridDiff;
-pub use draw::copy_rect;
+pub use draw::{copy_rect, copy_rect_clamped};
 pub use read::{GridIter, GridRead};
 pub use write::GridWrite;

--- a/src/ops/draw.rs
+++ b/src/ops/draw.rs
@@ -1,6 +1,6 @@
 use crate::{
     core::{Pos, Rect},
-    ops::{GridRead, GridWrite},
+    ops::{ExactSizeGrid, GridRead, GridWrite},
 };
 
 /// Copies a rectangular region from a source grid to a destination grid.
@@ -8,6 +8,10 @@ use crate::{
 /// The operation starts by copying the top-left corner to the specified offset; if there is
 /// insufficient space in the current grid, or the rectangle is out of bounds of the source grid,
 /// those individual cells are ignored and not copied to/from.
+///
+/// See [`copy_rect_clamped`] for a variant that's more efficient when `src`/`dst` implement
+/// [`ExactSizeGrid`], since it doesn't depend on
+/// [`GridBase::trim_rect`][crate::ops::GridBase::trim_rect]'s best-effort hint to bound its work.
 ///
 /// ## Examples
 ///
@@ -41,6 +45,69 @@ pub fn copy_rect<'a, E>(
         };
         let dst_pos = to + (src_pos - from.top_left());
         let _ = dst.set(dst_pos, value);
+    }
+}
+
+/// Copies a rectangular region from a source grid to a destination grid, clamping both
+/// rectangles to their respective grid bounds before copying.
+///
+/// `from` is first clamped to `src`'s bounds, the equivalent destination rectangle is translated
+/// from that clamp and clamped again to `dst`'s bounds, and the resulting rectangles - always the
+/// same size as each other, since the tighter of the two clamps wins on both sides - are copied
+/// position-for-position.
+///
+/// This requires [`ExactSizeGrid`] (in addition to [`GridRead`]/[`GridWrite`]) so both clamps can
+/// use the grid's authoritative size, rather than [`copy_rect`]'s best-effort
+/// [`trim_rect`][crate::ops::GridBase::trim_rect] hint: the copy only ever visits positions in the
+/// overlap of `from`, `src`, the translated destination rectangle, and `dst`, so it stays
+/// efficient even when `from` is much larger than `src`'s actual bounds.
+///
+/// If the clamped region ends up empty (`from` doesn't overlap `src` at all, or the translated
+/// destination rectangle doesn't overlap `dst` at all), this is a no-op.
+///
+/// ## Examples
+///
+/// ```rust
+/// use grixy::{core::{Pos, Rect}, transform::GridConvertExt as _, ops::{copy_rect_clamped, GridRead, GridWrite}, buf::GridBuf};
+///
+/// let src = GridBuf::new_filled(3, 3, 1);
+/// let mut dst = GridBuf::new(5, 5);
+/// copy_rect_clamped(&src.copied(), &mut dst, Rect::from_ltwh(0, 0, 3, 3), Pos::new(2, 2));
+///
+/// assert_eq!(dst.get(Pos::new(2, 2)), Some(&1));
+/// assert_eq!(dst.get(Pos::new(4, 4)), Some(&1));
+/// assert_eq!(dst.get(Pos::new(5, 5)), None);
+/// ```
+#[inline]
+pub fn copy_rect_clamped<'a, E>(
+    src: &'a (impl ExactSizeGrid + GridRead<Element<'a> = E>),
+    dst: &mut (impl ExactSizeGrid + GridWrite<Element = E>),
+    from: Rect,
+    to: Pos,
+) {
+    let from = from.intersect(Rect::from_ltwh(0, 0, src.width(), src.height()));
+    if from.is_empty() {
+        return;
+    }
+
+    let to = Rect::from_ltwh(to.x, to.y, from.width(), from.height()).intersect(Rect::from_ltwh(
+        0,
+        0,
+        dst.width(),
+        dst.height(),
+    ));
+    if to.is_empty() {
+        return;
+    }
+
+    // `to` may have been clamped tighter than `from` (e.g. if `to` sits near the destination's
+    // edge); shrink `from` to match before copying, so both rectangles are the same size and
+    // `pos_iter` visits them in lockstep.
+    let from = Rect::from_ltwh(from.left(), from.top(), to.width(), to.height());
+    for (src_pos, dst_pos) in from.pos_iter().zip(to.pos_iter()) {
+        if let Some(value) = src.get(src_pos) {
+            let _ = dst.set(dst_pos, value);
+        }
     }
 }
 
@@ -220,5 +287,165 @@ mod tests {
             0, 0, 0, 0, 0, 
             0, 0, 0, 0, 0,
         ]);
+    }
+
+    #[test]
+    fn copy_rect_clamped_within_bounds() {
+        #[rustfmt::skip]
+        let src = NaiveGrid::<i32>::with_cells(3, 3, [
+            1, 1, 1,
+            1, 1, 1,
+            1, 1, 1,
+        ]);
+
+        let mut dst = NaiveGrid::<i32>::new(5, 5);
+        copy_rect_clamped(
+            &src.copied(),
+            &mut dst,
+            Rect::from_ltwh(0, 0, 3, 3),
+            Pos::new(2, 2),
+        );
+
+        #[rustfmt::skip]
+        assert_eq!(dst.into_iter().collect::<Vec<_>>(),
+        &[
+            0, 0, 0, 0, 0,
+            0, 0, 0, 0, 0,
+            0, 0, 1, 1, 1,
+            0, 0, 1, 1, 1,
+            0, 0, 1, 1, 1,
+        ]);
+    }
+
+    #[test]
+    fn copy_rect_clamped_source_side_clip() {
+        #[rustfmt::skip]
+        let src = NaiveGrid::<i32>::with_cells(3, 3, [
+            1, 2, 3,
+            4, 5, 6,
+            7, 8, 9,
+        ]);
+
+        let mut dst = NaiveGrid::<i32>::new(5, 5);
+        // `from` is far larger than `src`'s actual 3x3 bounds; only the overlap is copied.
+        copy_rect_clamped(
+            &src.copied(),
+            &mut dst,
+            Rect::from_ltwh(0, 0, 10, 10),
+            Pos::new(0, 0),
+        );
+
+        #[rustfmt::skip]
+        assert_eq!(dst.into_iter().collect::<Vec<_>>(),
+        &[
+            1, 2, 3, 0, 0,
+            4, 5, 6, 0, 0,
+            7, 8, 9, 0, 0,
+            0, 0, 0, 0, 0,
+            0, 0, 0, 0, 0,
+        ]);
+    }
+
+    #[test]
+    fn copy_rect_clamped_destination_side_clip() {
+        // Same reproduction as `copy_rect`'s https://github.com/crates-lurey-io/grixy/issues/15.
+        #[rustfmt::skip]
+        let src = NaiveGrid::<i32>::with_cells(3, 3, [
+            1, 2, 3,
+            4, 5, 6,
+            7, 8, 9,
+        ]);
+
+        let mut dst = NaiveGrid::<i32>::new(5, 5);
+        copy_rect_clamped(
+            &src.copied(),
+            &mut dst,
+            Rect::from_ltwh(0, 0, 3, 3),
+            Pos::new(3, 3),
+        );
+
+        #[rustfmt::skip]
+        assert_eq!(dst.into_iter().collect::<Vec<_>>(),
+        &[
+            0, 0, 0, 0, 0,
+            0, 0, 0, 0, 0,
+            0, 0, 0, 0, 0,
+            0, 0, 0, 1, 2,
+            0, 0, 0, 4, 5,
+        ]);
+    }
+
+    #[test]
+    fn copy_rect_clamped_both_sides_clip_takes_the_tighter_bound() {
+        #[rustfmt::skip]
+        let src = NaiveGrid::<i32>::with_cells(4, 4, [
+             1,  2,  3,  4,
+             5,  6,  7,  8,
+             9, 10, 11, 12,
+            13, 14, 15, 16,
+        ]);
+
+        let mut dst = NaiveGrid::<i32>::new(6, 6);
+        // Source-side clamp narrows `from` from 10x10 to 4x4 (src's real size); destination-side
+        // clamp then narrows it further to 3x3 (dst only has 3 columns/rows left from `to`). The
+        // final copy must use the tighter (3x3) bound on *both* sides, taking the top-left 3x3 of
+        // the already source-clamped region - not the top-left 3x3 of the original 10x10 `from`.
+        copy_rect_clamped(
+            &src.copied(),
+            &mut dst,
+            Rect::from_ltwh(0, 0, 10, 10),
+            Pos::new(3, 3),
+        );
+
+        #[rustfmt::skip]
+        assert_eq!(dst.into_iter().collect::<Vec<_>>(),
+        &[
+            0, 0, 0,  0,  0,  0,
+            0, 0, 0,  0,  0,  0,
+            0, 0, 0,  0,  0,  0,
+            0, 0, 0,  1,  2,  3,
+            0, 0, 0,  5,  6,  7,
+            0, 0, 0,  9, 10, 11,
+        ]);
+    }
+
+    #[test]
+    fn copy_rect_clamped_source_completely_out_of_bounds() {
+        #[rustfmt::skip]
+        let src = NaiveGrid::<i32>::with_cells(3, 3, [
+            1, 1, 1,
+            1, 1, 1,
+            1, 1, 1,
+        ]);
+
+        let mut dst = NaiveGrid::<i32>::new(5, 5);
+        copy_rect_clamped(
+            &src.copied(),
+            &mut dst,
+            Rect::from_ltwh(5, 5, 2, 2),
+            Pos::new(0, 0),
+        );
+
+        assert!(dst.into_iter().all(|cell| cell == 0));
+    }
+
+    #[test]
+    fn copy_rect_clamped_destination_completely_out_of_bounds() {
+        #[rustfmt::skip]
+        let src = NaiveGrid::<i32>::with_cells(3, 3, [
+            1, 1, 1,
+            1, 1, 1,
+            1, 1, 1,
+        ]);
+
+        let mut dst = NaiveGrid::<i32>::new(5, 5);
+        copy_rect_clamped(
+            &src.copied(),
+            &mut dst,
+            Rect::from_ltwh(0, 0, 3, 3),
+            Pos::new(10, 10),
+        );
+
+        assert!(dst.into_iter().all(|cell| cell == 0));
     }
 }

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -14,6 +14,7 @@ pub use crate::buf::{GridBuf, bits::GridBits};
 pub use crate::core::{GridError, HasSize as _, Pos, Rect, Size};
 pub use crate::ops::{
     ExactSizeGrid as _, GridBase, GridDiff as _, GridIter as _, GridRead, GridWrite, copy_rect,
+    copy_rect_clamped,
     layout::{Block, ColumnMajor, Layout as _, LinearLayout as _, RowMajor},
 };
 pub use crate::transform::GridConvertExt as _;

--- a/src/test.rs
+++ b/src/test.rs
@@ -9,7 +9,7 @@ use alloc::{vec, vec::Vec};
 use crate::{
     core::{GridError, Size},
     ops::{
-        GridBase, GridRead, GridWrite,
+        ExactSizeGrid, GridBase, GridRead, GridWrite,
         layout::{self, Layout as _},
     },
 };
@@ -56,6 +56,16 @@ impl<T> GridBase for NaiveGrid<T> {
     fn size_hint(&self) -> (Size, Option<Size>) {
         let size = Size::new(self.width, self.height);
         (size, Some(size))
+    }
+}
+
+impl<T> ExactSizeGrid for NaiveGrid<T> {
+    fn width(&self) -> usize {
+        self.width
+    }
+
+    fn height(&self) -> usize {
+        self.height
     }
 }
 

--- a/src/transform.rs
+++ b/src/transform.rs
@@ -342,6 +342,60 @@ mod tests {
     }
 
     #[test]
+    fn grid_view_get_with_offset_bounds() {
+        // Regression test for https://github.com/crates-lurey-io/grixy/issues/16: `Viewed::get`
+        // used to double-offset `pos` (and underflow-panic near the origin) whenever
+        // `bounds.top_left() != Pos::ORIGIN`. Every other `view` test above only exercises
+        // origin-aligned bounds, where subtracting or adding the (zero) offset is indistinguishable.
+        #[rustfmt::skip]
+        let grid = GridBuf::<_, _, RowMajor>::from_buffer(vec![
+            1, 2, 3,
+            4, 5, 6,
+            7, 8, 9,
+        ], 3);
+        let view = grid.view(Rect::from_ltwh(1, 1, 2, 2));
+
+        // View-local (0, 0) is the view's own top-left, i.e. source (1, 1) = 5. Used to panic
+        // with "attempt to subtract with overflow".
+        assert_eq!(view.get(Pos::new(0, 0)), Some(&5));
+        // View-local (1, 1) is the view's own bottom-right, i.e. source (2, 2) = 9.
+        assert_eq!(view.get(Pos::new(1, 1)), Some(&9));
+        // Out of the view's own 2x2 bounds, even though it's a valid position in `grid`.
+        assert_eq!(view.get(Pos::new(2, 2)), None);
+    }
+
+    #[test]
+    fn grid_view_iter_rect_with_offset_bounds() {
+        #[rustfmt::skip]
+        let grid = GridBuf::<_, _, RowMajor>::from_buffer(vec![
+            1, 2, 3,
+            4, 5, 6,
+            7, 8, 9,
+        ], 3);
+        let view = grid.view(Rect::from_ltwh(1, 1, 2, 2));
+
+        // Used to underflow-panic translating (0, 0, 2, 2) by `bounds.top_left()` in the wrong
+        // direction.
+        let elements: Vec<_> = view.iter_rect(Rect::from_ltwh(0, 0, 2, 2)).collect();
+        assert_eq!(elements, &[&5, &6, &8, &9]);
+    }
+
+    #[test]
+    fn grid_view_iter_rect_clamps_oversized_query_to_view_bounds() {
+        #[rustfmt::skip]
+        let grid = GridBuf::<_, _, RowMajor>::from_buffer(vec![
+            1, 2, 3,
+            4, 5, 6,
+            7, 8, 9,
+        ], 3);
+        let view = grid.view(Rect::from_ltwh(1, 1, 2, 2));
+
+        // A query larger than the view's own 2x2 size must not leak cells from outside `bounds`.
+        let elements: Vec<_> = view.iter_rect(Rect::from_ltwh(0, 0, 10, 10)).collect();
+        assert_eq!(elements, &[&5, &6, &8, &9]);
+    }
+
+    #[test]
     fn grid_scaled_size() {
         let grid = GridBuf::<u8, _, _>::new(10, 10);
         let scaled = grid.scale(2);

--- a/src/transform/viewed.rs
+++ b/src/transform/viewed.rs
@@ -48,15 +48,21 @@ where
     type Layout = G::Layout;
 
     fn get(&self, pos: Pos) -> Option<Self::Element<'_>> {
-        let pos = pos - self.bounds.top_left();
-        if !self.bounds.contains_pos(pos) {
+        // `pos` is in view-local coordinates (0..width, 0..height); check it against the view's
+        // own (zero-based) size *before* translating, then add `bounds.top_left()` to reach the
+        // source's coordinate space. Checking the already-translated `pos` against `self.bounds`
+        // (which is itself in source coordinates) double-offsets, and for a `pos` smaller than
+        // `bounds.top_left()` underflows.
+        if pos.x >= self.bounds.width() || pos.y >= self.bounds.height() {
             return None;
         }
-        self.source.get(pos)
+        self.source.get(pos + self.bounds.top_left())
     }
 
     fn iter_rect(&self, bounds: Rect) -> impl Iterator<Item = Self::Element<'_>> {
-        let bounds = bounds - self.bounds.top_left();
+        // Clamp the (view-local) query to the view's own size first, so an oversized `bounds`
+        // can't leak cells from outside the view, then translate into source coordinates.
+        let bounds = self.trim_rect(bounds) + self.bounds.top_left();
         self.source.iter_rect(bounds)
     }
 }


### PR DESCRIPTION
Consolidates fixes for #16 and the `copy_rect_clamped` addition from #17 into
one release, on top of #18 (already merged). Since none of this has actually
been published to crates.io yet, there's no reason to burn three separate
version numbers (and fight CHANGELOG conflicts between three PRs) for changes
that haven't shipped - this is one PR, one version bump, one CHANGELOG entry.

Three commits, each independently reviewable, intended to land as a single
squash-merge:

## 1. `fix: transform::Viewed::get double-offsets bounds` (#16)

`Viewed::get` translated `pos` by subtracting `bounds.top_left()` and then
checked the *already-translated* position against the *untranslated*
`bounds` - a double offset that only worked when `bounds.top_left() ==
Pos::ORIGIN` (the only case the crate's own tests covered) and
underflow-panicked otherwise. `Viewed::iter_rect` had the same directional
bug plus no clamping. Fixed by treating the incoming position/rect as
view-local and adding `bounds.top_left()` (not subtracting) to reach the
source's coordinate space.

## 2. `feat: add copy_rect_clamped`

Originally proposed in #17 as a workaround for #15 (with `copy_rect`
deprecated alongside it), on the premise that a correct fix needed an
`ExactSizeGrid` bound that would be a breaking addition to `copy_rect`
itself. #18 (merged) found a way to fix `copy_rect`'s row-misalignment bug
in place without a new bound, which made that premise moot - so this version
does **not** deprecate `copy_rect`. Instead, `copy_rect_clamped` is added as
a genuinely complementary, `ExactSizeGrid`-bounded variant: it clamps both
rectangles using each grid's *authoritative* size before copying, so it's
bounded to the actual overlapping region even when `from` is much larger
than the source and the source has no accurate `size_hint` - `copy_rect`
can only narrow its work via `GridBase::trim_rect`'s best-effort hint.

## 3. `chore: release 0.6.2`

One version bump, one CHANGELOG entry covering both changes above (plus
folding in #18's already-merged fix, which is why the CHANGELOG diff touches
that section). Confirmed with `cargo-semver-checks` against the published
`0.6.1` baseline that a **patch** bump is sufficient - this batch is purely
additive/bug-fix, no removals or breaking signature changes to existing
public items:

```
Checking grixy v0.6.1 -> v0.6.2 (minor change)
 Checked [   0.011s] 196 checks: 196 pass, 57 skip
 Summary no semver update required
```

("minor change" in the tool's output is `cargo-semver-checks`' label for a
0.x *patch*-slot bump, since Cargo's own caret matching treats the minor
component as the breaking boundary pre-1.0.)

## Testing

- `cargo just check` (fmt, clippy `-D warnings`, doc-check) passes on the
  final state.
- `cargo just test-all` (unit + doctests): 115 unit tests, 26 doctests, all
  passing.
- New regression tests: `grid_view_get_with_offset_bounds`,
  `grid_view_iter_rect_with_offset_bounds`,
  `grid_view_iter_rect_clamps_oversized_query_to_view_bounds` for #16;
  `copy_rect_clamped_within_bounds`, `copy_rect_clamped_source_side_clip`,
  `copy_rect_clamped_destination_side_clip`,
  `copy_rect_clamped_both_sides_clip_takes_the_tighter_bound`,
  `copy_rect_clamped_source_completely_out_of_bounds`,
  `copy_rect_clamped_destination_completely_out_of_bounds` for the new
  function.
- `benches/blit.rs` and `examples/mono-font-raster.rs` migrated to
  `copy_rect_clamped` (both build cleanly).
