### PR TITLE
chore: bump ixy to 0.7.0, release 0.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,21 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.7.0] - 2026-08-03
+
+### Dependencies
+
+- Bumped `ixy` from `0.6.1` to `0.7.0`. All of `0.7.0`'s changes are additive (`Rect::clamp_within`/
+  `centered_in`, `Rect::inset`/`outset`, `Size` parity with `Pos`, `Rect * Size`, plus a fix so
+  `Rect::row_rect`/`col_rect` actually clamp as documented) and grixy doesn't use `row_rect`/
+  `col_rect`, so no source changes were needed here. Bumped as a minor (not patch) release
+  regardless: `grixy::core::{Pos, Rect, Size}` are type aliases directly onto `ixy`'s types, so any
+  consumer that also depends on `ixy` directly (not just through grixy) and passes its own
+  `ixy 0.6.x`-typed values into grixy's API would fail to compile against a plain patch bump - a
+  new major/minor of a re-exported public dependency is a breaking change for grixy's own API
+  surface even though `ixy` itself only added things. This is exactly the failure a downstream
+  consumer (retroglyph) hit trying to move to `ixy 0.7.0` while grixy was still pinned to `^0.6.1`.
+
 ## [0.6.2] - 2026-08-02
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -320,7 +320,7 @@ dependencies = [
 
 [[package]]
 name = "grixy"
-version = "0.6.2"
+version = "0.7.0"
 dependencies = [
  "bytemuck",
  "criterion",
@@ -409,9 +409,9 @@ checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
 
 [[package]]
 name = "ixy"
-version = "0.6.1"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "947712713bffab262e4ef564ace3eadecc59d041244c566bcc2e7d1d43dff5cf"
+checksum = "5718f46939aa15fd650875276d05d30789de310bb9ca3831d5ff2c3b9db96a6b"
 dependencies = [
  "serde",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ rust-version = "1.87"
 documentation = "https://docs.rs/grixy"
 keywords = ["2d", "grid", "embedded", "no-std", "gamedev"]
 categories = ["game-development", "mathematics", "embedded", "no-std"]
-version = "0.6.2"
+version = "0.7.0"
 
 [lints.rust]
 missing_docs = "deny"
@@ -48,7 +48,7 @@ serde = ["dep:serde", "ixy/serde"]
 all-features = true
 
 [dependencies]
-ixy = { version = "0.6.1" }
+ixy = { version = "0.7.0" }
 serde = { version = "1.0", optional = true, features = ["derive"] }
 
 [dev-dependencies]


### PR DESCRIPTION
Unblocks https://github.com/crates-lurey-io/retroglyph/issues/830, which needs `ixy 0.7.0`'s
new `Rect`/`Size` APIs but is stuck behind grixy's `ixy = "^0.6.1"` pin: with both `ixy` versions
in the graph, grixy's re-exported `ixy::Rect<usize>` (from 0.6.1) and retroglyph's own direct
`ixy::Rect<usize>` (from 0.7.0) are incompatible types (E0308).

## What changed

- `ixy` bumped from `0.6.1` to `0.7.0` in `Cargo.toml`/`Cargo.lock`.
- No source changes: `ixy 0.7.0` is purely additive (`Rect::clamp_within`/`centered_in`,
  `Rect::inset`/`outset`, `Size` parity with `Pos`, `Rect * Size`, plus a `Rect::row_rect`/
  `col_rect` clamping fix) and grixy doesn't use `row_rect`/`col_rect`.

## Why this is a minor bump, not a patch

`grixy::core::{Pos, Rect, Size}` are type aliases directly onto `ixy`'s types. Any consumer that
also depends on `ixy` directly (not just through grixy) and passes its own `ixy 0.6.x`-typed
values into grixy's API would fail to compile against a plain patch bump - a new minor of a
re-exported public dependency is a breaking change for grixy's own API surface even though `ixy`
itself only added things. This is exactly the retroglyph failure above, just from the other
direction (grixy holding a consumer back, instead of a consumer's re-export holding grixy back).

## Testing

- `cargo build/test/clippy --all-features --all-targets` against `ixy 0.7.0`: unchanged, clean.
- `cargo just check` (fmt, clippy `-D warnings`, doc-check): passes.
- `cargo just test-all`: 115 unit tests + 26 doctests, all passing, unchanged.
- `cargo just msrv` (1.87): passes (`ixy 0.7.0` has the same `rust-version = "1.87"`).
- `cargo just semver-checks` against the published `0.6.2` baseline: reports "no semver update
  required" at the tool's own major-tier check (expected - it doesn't have a lint for "public
  dependency's own version changed", which is exactly the manual case reasoned through above).
- `cargo publish --dry-run`: packages and verifies cleanly at `0.7.0`.
